### PR TITLE
feat: propagate :managed option through Cluster and Sentinel

### DIFF
--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -29,6 +29,10 @@ defmodule RedisServerWrapper.Cluster do
     * `:timeout` - startup timeout per node in ms (default: 10_000)
     * `:cluster_node_timeout` - cluster node timeout in ms (default: 5000)
     * `:extra` - extra redis config directives as `[{key, value}]`
+    * `:managed` - when `true` (default), each node runs as a Port tied
+      to the BEAM lifecycle. When `false`, nodes daemonize independently
+      and survive BEAM exits; combine with `detach/1` so this GenServer
+      will not tear them down on terminate either.
   """
 
   use GenServer
@@ -121,6 +125,7 @@ defmodule RedisServerWrapper.Cluster do
     timeout = Keyword.get(opts, :timeout, 10_000)
     cluster_node_timeout = Keyword.get(opts, :cluster_node_timeout, 5000)
     extra = Keyword.get(opts, :extra, [])
+    managed = Keyword.get(opts, :managed, true)
 
     total_nodes = masters * (1 + replicas)
     ports = Enum.map(0..(total_nodes - 1), &(base_port + &1))
@@ -138,7 +143,8 @@ defmodule RedisServerWrapper.Cluster do
            redis_cli_bin,
            timeout,
            cluster_node_timeout,
-           extra
+           extra,
+           managed
          ) do
       {:ok, node_pids} ->
         # Form the cluster
@@ -282,7 +288,8 @@ defmodule RedisServerWrapper.Cluster do
          redis_cli_bin,
          timeout,
          cluster_node_timeout,
-         extra
+         extra,
+         managed
        ) do
     results =
       Enum.reduce_while(ports, {:ok, []}, fn port, {:ok, acc} ->
@@ -294,6 +301,7 @@ defmodule RedisServerWrapper.Cluster do
             redis_server_bin: redis_server_bin,
             redis_cli_bin: redis_cli_bin,
             timeout: timeout,
+            managed: managed,
             cluster_enabled: true,
             cluster_config_file: "nodes-#{port}.conf",
             cluster_node_timeout: cluster_node_timeout,

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -134,18 +134,19 @@ defmodule RedisServerWrapper.Cluster do
     cleanup_ports(ports, bind, redis_cli_bin, password)
     Process.sleep(500)
 
+    node_opts = %{
+      bind: bind,
+      password: password,
+      redis_server_bin: redis_server_bin,
+      redis_cli_bin: redis_cli_bin,
+      timeout: timeout,
+      cluster_node_timeout: cluster_node_timeout,
+      extra: extra,
+      managed: managed
+    }
+
     # Start each node as a Server GenServer
-    case start_nodes(
-           ports,
-           bind,
-           password,
-           redis_server_bin,
-           redis_cli_bin,
-           timeout,
-           cluster_node_timeout,
-           extra,
-           managed
-         ) do
+    case start_nodes(ports, node_opts) do
       {:ok, node_pids} ->
         # Form the cluster
         seed_cli = Cli.new(bin: redis_cli_bin, host: bind, port: base_port, password: password)
@@ -280,33 +281,23 @@ defmodule RedisServerWrapper.Cluster do
   # Internal
   # -------------------------------------------------------------------
 
-  defp start_nodes(
-         ports,
-         bind,
-         password,
-         redis_server_bin,
-         redis_cli_bin,
-         timeout,
-         cluster_node_timeout,
-         extra,
-         managed
-       ) do
+  defp start_nodes(ports, node_opts) do
     results =
       Enum.reduce_while(ports, {:ok, []}, fn port, {:ok, acc} ->
         opts =
           [
             port: port,
-            bind: bind,
-            password: password,
-            redis_server_bin: redis_server_bin,
-            redis_cli_bin: redis_cli_bin,
-            timeout: timeout,
-            managed: managed,
+            bind: node_opts.bind,
+            password: node_opts.password,
+            redis_server_bin: node_opts.redis_server_bin,
+            redis_cli_bin: node_opts.redis_cli_bin,
+            timeout: node_opts.timeout,
+            managed: node_opts.managed,
             cluster_enabled: true,
             cluster_config_file: "nodes-#{port}.conf",
-            cluster_node_timeout: cluster_node_timeout,
+            cluster_node_timeout: node_opts.cluster_node_timeout,
             save: :disabled
-          ] ++ extra_to_opts(extra)
+          ] ++ extra_to_opts(node_opts.extra)
 
         # Clean any stale cluster config from previous runs
         clean_node_dir(port)

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -139,28 +139,18 @@ defmodule RedisServerWrapper.Sentinel do
     cleanup_ports(all_ports, bind, redis_cli_bin, password)
     Process.sleep(500)
 
-    with {:ok, master_pid} <-
-           start_master(
-             master_port,
-             bind,
-             password,
-             redis_server_bin,
-             redis_cli_bin,
-             timeout,
-             managed
-           ),
+    node_opts = %{
+      bind: bind,
+      password: password,
+      redis_server_bin: redis_server_bin,
+      redis_cli_bin: redis_cli_bin,
+      timeout: timeout,
+      managed: managed
+    }
+
+    with {:ok, master_pid} <- start_master(master_port, node_opts),
          {:ok, replica_pids} <-
-           start_replicas(
-             num_replicas,
-             replica_base_port,
-             master_port,
-             bind,
-             password,
-             redis_server_bin,
-             redis_cli_bin,
-             timeout,
-             managed
-           ),
+           start_replicas(num_replicas, replica_base_port, master_port, node_opts),
          # Let replication link up
          _ <- Process.sleep(1000),
          {:ok, sentinel_os_pids, sentinel_dir} <-
@@ -328,47 +318,36 @@ defmodule RedisServerWrapper.Sentinel do
   # Internal
   # -------------------------------------------------------------------
 
-  defp start_master(port, bind, password, redis_server_bin, redis_cli_bin, timeout, managed) do
+  defp start_master(port, node_opts) do
     Server.start_link(
       port: port,
-      bind: bind,
-      password: password,
-      redis_server_bin: redis_server_bin,
-      redis_cli_bin: redis_cli_bin,
-      timeout: timeout,
-      managed: managed,
+      bind: node_opts.bind,
+      password: node_opts.password,
+      redis_server_bin: node_opts.redis_server_bin,
+      redis_cli_bin: node_opts.redis_cli_bin,
+      timeout: node_opts.timeout,
+      managed: node_opts.managed,
       save: :disabled
     )
   end
 
-  defp start_replicas(0, _base_port, _master_port, _bind, _pw, _rsb, _rcb, _timeout, _managed),
-    do: {:ok, []}
+  defp start_replicas(0, _base_port, _master_port, _node_opts), do: {:ok, []}
 
-  defp start_replicas(
-         count,
-         base_port,
-         master_port,
-         bind,
-         password,
-         redis_server_bin,
-         redis_cli_bin,
-         timeout,
-         managed
-       ) do
+  defp start_replicas(count, base_port, master_port, node_opts) do
     results =
       Enum.reduce_while(0..(count - 1), {:ok, []}, fn i, {:ok, acc} ->
         port = base_port + i
 
         opts = [
           port: port,
-          bind: bind,
-          password: password,
-          masterauth: password,
-          replicaof: {bind, master_port},
-          redis_server_bin: redis_server_bin,
-          redis_cli_bin: redis_cli_bin,
-          timeout: timeout,
-          managed: managed,
+          bind: node_opts.bind,
+          password: node_opts.password,
+          masterauth: node_opts.password,
+          replicaof: {node_opts.bind, master_port},
+          redis_server_bin: node_opts.redis_server_bin,
+          redis_cli_bin: node_opts.redis_cli_bin,
+          timeout: node_opts.timeout,
+          managed: node_opts.managed,
           save: :disabled
         ]
 

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -30,6 +30,11 @@ defmodule RedisServerWrapper.Sentinel do
     * `:redis_server_bin` - redis-server binary path
     * `:redis_cli_bin` - redis-cli binary path
     * `:timeout` - startup timeout per node in ms (default: 10_000)
+    * `:managed` - when `true` (default), master and replicas run as
+      Ports tied to the BEAM lifecycle. When `false`, they daemonize
+      independently and survive BEAM exits; combine with `detach/1`
+      so this GenServer will not tear them down on terminate either.
+      Sentinel processes always daemonize regardless of this flag.
   """
 
   use GenServer
@@ -123,6 +128,7 @@ defmodule RedisServerWrapper.Sentinel do
 
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, 10_000)
+    managed = Keyword.get(opts, :managed, true)
 
     all_ports =
       [master_port] ++
@@ -134,7 +140,15 @@ defmodule RedisServerWrapper.Sentinel do
     Process.sleep(500)
 
     with {:ok, master_pid} <-
-           start_master(master_port, bind, password, redis_server_bin, redis_cli_bin, timeout),
+           start_master(
+             master_port,
+             bind,
+             password,
+             redis_server_bin,
+             redis_cli_bin,
+             timeout,
+             managed
+           ),
          {:ok, replica_pids} <-
            start_replicas(
              num_replicas,
@@ -144,7 +158,8 @@ defmodule RedisServerWrapper.Sentinel do
              password,
              redis_server_bin,
              redis_cli_bin,
-             timeout
+             timeout,
+             managed
            ),
          # Let replication link up
          _ <- Process.sleep(1000),
@@ -313,7 +328,7 @@ defmodule RedisServerWrapper.Sentinel do
   # Internal
   # -------------------------------------------------------------------
 
-  defp start_master(port, bind, password, redis_server_bin, redis_cli_bin, timeout) do
+  defp start_master(port, bind, password, redis_server_bin, redis_cli_bin, timeout, managed) do
     Server.start_link(
       port: port,
       bind: bind,
@@ -321,11 +336,12 @@ defmodule RedisServerWrapper.Sentinel do
       redis_server_bin: redis_server_bin,
       redis_cli_bin: redis_cli_bin,
       timeout: timeout,
+      managed: managed,
       save: :disabled
     )
   end
 
-  defp start_replicas(0, _base_port, _master_port, _bind, _pw, _rsb, _rcb, _timeout),
+  defp start_replicas(0, _base_port, _master_port, _bind, _pw, _rsb, _rcb, _timeout, _managed),
     do: {:ok, []}
 
   defp start_replicas(
@@ -336,7 +352,8 @@ defmodule RedisServerWrapper.Sentinel do
          password,
          redis_server_bin,
          redis_cli_bin,
-         timeout
+         timeout,
+         managed
        ) do
     results =
       Enum.reduce_while(0..(count - 1), {:ok, []}, fn i, {:ok, acc} ->
@@ -351,6 +368,7 @@ defmodule RedisServerWrapper.Sentinel do
           redis_server_bin: redis_server_bin,
           redis_cli_bin: redis_cli_bin,
           timeout: timeout,
+          managed: managed,
           save: :disabled
         ]
 


### PR DESCRIPTION
## Summary

- `Cluster.start_link` and `Sentinel.start_link` now accept a `:managed` option (default `true`, backward compatible) that flows through to every child `Server.start_link`.
- Previously this was hardcoded away inside the private `start_nodes`, `start_master`, and `start_replicas` helpers, so multi-node topologies were effectively managed-only.
- `Cluster.detach/1` and `Sentinel.detach/1` silently no-op'd on each child because `Server.detach/1` returns `{:error, :managed_server}` in managed mode. With this change, detach actually works for multi-node topologies.

## Motivation

A downstream consumer wants clusters and sentinels to survive BEAM exit for the same reasons standalone `Server` already can: the BEAM is a dev/test harness, not the thing that owns the Redis processes' lifetime. Previously you could start a standalone `Server` with `managed: false` + `detach/1` and the redis-server would keep running after the GenServer died, but the same pattern didn't work for `Cluster.start_link` or `Sentinel.start_link` because those hardcoded the per-node options.

## Scope of change

- Minimal, additive, backward compatible.
- Default remains `managed: true` everywhere.
- Sentinel processes themselves (the raw OS processes spawned via `System.cmd` with `daemonize: yes`) are unaffected; they always daemonize regardless. The flag only governs the Server-based master and replicas.
- No public API removal or rename.

## Test plan

- [x] `mix test` on main passes (35/35)
- [x] `mix test` on this branch passes (35/35)
- [x] Manual verification: 3-master cluster with `managed: false` + `detach` survives wrapper GenServer death; all three nodes keep listening until explicit `Cli.shutdown`
- [x] Manual verification: sentinel topology (master + 2 replicas + 3 sentinels) with `managed: false` + `detach` survives wrapper GenServer death; all six processes keep listening until explicit cleanup
- [ ] CI