### PR TITLE
fix: detect non-RESP peers in wait_for_ready; move Cluster default off 7000

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -22,7 +22,7 @@ IO.puts("""
 
   Manager (persistent, redis-up style):
     Manager.start_basic(port: 6400)
-    Manager.start_cluster(masters: 3, base_port: 7000)
+    Manager.start_cluster(masters: 3, base_port: 7100)
     Manager.start_sentinel(master_port: 6390)
     Manager.list()
     Manager.info("redis-basic-1")

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ RedisServerWrapper.Server.stop(server)
 ### Cluster
 
 ```elixir
-{:ok, cluster} = RedisServerWrapper.start_cluster(masters: 3, base_port: 7000)
+{:ok, cluster} = RedisServerWrapper.start_cluster(masters: 3, base_port: 7100)
 
 RedisServerWrapper.Cluster.healthy?(cluster)
 #=> true
 
 RedisServerWrapper.Cluster.node_addrs(cluster)
-#=> ["127.0.0.1:7000", "127.0.0.1:7001", "127.0.0.1:7002"]
+#=> ["127.0.0.1:7100", "127.0.0.1:7101", "127.0.0.1:7102"]
 
 RedisServerWrapper.Cluster.stop(cluster)
 ```
@@ -129,7 +129,7 @@ alias RedisServerWrapper.{Chaos, Cluster, Server}
 {:ok, cluster} = RedisServerWrapper.start_cluster(
   masters: 3,
   replicas_per_master: 1,
-  base_port: 7000
+  base_port: 7100
 )
 
 # Kill the master owning a key's hash slot

--- a/lib/redis_server_wrapper.ex
+++ b/lib/redis_server_wrapper.ex
@@ -13,7 +13,7 @@ defmodule RedisServerWrapper do
       RedisServerWrapper.Server.stop(server)
 
       # Cluster
-      {:ok, cluster} = RedisServerWrapper.start_cluster(masters: 3, base_port: 7000)
+      {:ok, cluster} = RedisServerWrapper.start_cluster(masters: 3, base_port: 7100)
       RedisServerWrapper.Cluster.healthy?(cluster)
       RedisServerWrapper.Cluster.stop(cluster)
 

--- a/lib/redis_server_wrapper/cli.ex
+++ b/lib/redis_server_wrapper/cli.ex
@@ -74,8 +74,15 @@ defmodule RedisServerWrapper.Cli do
 
   @doc """
   Polls with PING until the server responds or timeout (ms) is reached.
+
+  Returns `{:error, {:unexpected_reply, output}}` if the peer accepts the
+  connection but responds with something other than `PONG` (or a transient
+  `LOADING`/`BUSY` reply). This catches the common case of another service
+  holding the port (e.g. macOS AirPlay on 7000) or a different redis-server
+  with a mismatched password already bound to the port.
   """
-  @spec wait_for_ready(t(), non_neg_integer()) :: :ok | {:error, :timeout}
+  @spec wait_for_ready(t(), non_neg_integer()) ::
+          :ok | {:error, :timeout} | {:error, {:unexpected_reply, String.t()}}
   def wait_for_ready(%__MODULE__{} = cli, timeout_ms \\ 10_000) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_for_ready(cli, deadline)
@@ -85,12 +92,40 @@ defmodule RedisServerWrapper.Cli do
     if System.monotonic_time(:millisecond) >= deadline do
       {:error, :timeout}
     else
-      if ping(cli) do
-        :ok
-      else
-        Process.sleep(250)
-        do_wait_for_ready(cli, deadline)
+      case ping_status(cli) do
+        :ready ->
+          :ok
+
+        :not_ready ->
+          Process.sleep(250)
+          do_wait_for_ready(cli, deadline)
+
+        {:unexpected, output} ->
+          {:error, {:unexpected_reply, output}}
       end
+    end
+  end
+
+  # Classify a PING attempt:
+  #   :ready                - got PONG
+  #   :not_ready            - connection refused, or transient LOADING/BUSY reply
+  #   {:unexpected, output} - accepted the connection but replied with
+  #                           something that isn't PONG or a known transient;
+  #                           almost always means the port is held by a
+  #                           different service (or a redis with different auth)
+  defp ping_status(%__MODULE__{} = cli) do
+    case run(cli, ["PING"]) do
+      {:ok, "PONG"} -> :ready
+      {:ok, output} -> classify_ok_reply(output)
+      {:error, _} -> :not_ready
+    end
+  end
+
+  defp classify_ok_reply(output) do
+    cond do
+      output =~ ~r/\bLOADING\b/ -> :not_ready
+      output =~ ~r/\bBUSY\b/ -> :not_ready
+      true -> {:unexpected, output}
     end
   end
 

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -10,7 +10,7 @@ defmodule RedisServerWrapper.Cluster do
       {:ok, pid} = RedisServerWrapper.Cluster.start_link(
         masters: 3,
         replicas_per_master: 1,
-        base_port: 7000
+        base_port: 7100
       )
 
       RedisServerWrapper.Cluster.healthy?(pid)
@@ -21,7 +21,9 @@ defmodule RedisServerWrapper.Cluster do
 
     * `:masters` - number of master nodes (default: 3)
     * `:replicas_per_master` - replicas per master (default: 0)
-    * `:base_port` - starting port (default: 7000)
+    * `:base_port` - starting port (default: 7100). Note: 7000 is avoided
+      because macOS AirPlay Receiver binds it by default, which causes
+      confusing cluster-start failures on Mac.
     * `:bind` - bind address (default: "127.0.0.1")
     * `:password` - Redis password (default: nil)
     * `:redis_server_bin` - redis-server binary path
@@ -114,7 +116,7 @@ defmodule RedisServerWrapper.Cluster do
 
     masters = Keyword.get(opts, :masters, 3)
     replicas = Keyword.get(opts, :replicas_per_master, 0)
-    base_port = Keyword.get(opts, :base_port, 7000)
+    base_port = Keyword.get(opts, :base_port, 7100)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
     password = Keyword.get(opts, :password)
 

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -8,7 +8,7 @@ defmodule RedisServerWrapper.Manager do
   ## Usage
 
       Manager.start_basic(port: 6400)
-      Manager.start_cluster(masters: 3, base_port: 7000)
+      Manager.start_cluster(masters: 3, base_port: 7100)
       Manager.start_sentinel(master_port: 6390)
 
       Manager.list()
@@ -121,7 +121,7 @@ defmodule RedisServerWrapper.Manager do
     * `:name` - instance name (auto-generated if omitted)
     * `:masters` - number of masters (default: 3)
     * `:replicas_per_master` - replicas per master (default: 0)
-    * `:base_port` - starting port (default: 7000)
+    * `:base_port` - starting port (default: 7100)
     * `:password` - Redis password (auto-generated if omitted)
     * `:bind` - bind address (default: "127.0.0.1")
   """
@@ -132,7 +132,7 @@ defmodule RedisServerWrapper.Manager do
     password = resolve_password(opts)
     masters = Keyword.get(opts, :masters, 3)
     replicas = Keyword.get(opts, :replicas_per_master, 0)
-    base_port = Keyword.get(opts, :base_port, 7000)
+    base_port = Keyword.get(opts, :base_port, 7100)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
 
     if Map.has_key?(state.instances, name) do

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -477,6 +477,9 @@ defmodule RedisServerWrapper.Sentinel do
 
           {:error, :timeout} ->
             {:error, {:sentinel_start_timeout, port}}
+
+          {:error, {:unexpected_reply, reply}} ->
+            {:error, {:sentinel_port_in_use, port, reply}}
         end
 
       {output, code} ->

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -354,6 +354,10 @@ defmodule RedisServerWrapper.Server do
       {:error, :timeout} ->
         safe_port_close(port_ref)
         {:error, {:server_start_timeout, config.port}}
+
+      {:error, {:unexpected_reply, reply}} ->
+        safe_port_close(port_ref)
+        {:error, {:port_in_use, config.port, reply}}
     end
   end
 
@@ -406,6 +410,9 @@ defmodule RedisServerWrapper.Server do
 
           {:error, :timeout} ->
             {:error, {:server_start_timeout, config.port}}
+
+          {:error, {:unexpected_reply, reply}} ->
+            {:error, {:port_in_use, config.port, reply}}
         end
 
       {output, code} ->


### PR DESCRIPTION
## Summary

- **#22** `Cli.wait_for_ready` now distinguishes three states per PING: `PONG` (ready), transient `LOADING`/`BUSY` (retry), and any other accepted-but-non-PONG reply (fail fast with `{:error, {:unexpected_reply, output}}`). `Server` and `Sentinel` surface it as `{:port_in_use, port, reply}` / `{:sentinel_port_in_use, port, reply}`, so a port held by a non-Redis listener (or a mismatched-auth Redis) returns immediately instead of timing out silently after ~10s.
- **#21** `Cluster` and `Manager.start_cluster` default `:base_port` changes from `7000` to `7100`. Avoids the macOS AirPlay Receiver conflict that makes cluster startup hang on every Mac with default settings. README, moduledocs, and `.iex.exs` example updated.

Breaking change for callers relying on the 7000 default, but the breakage is loud -- either pass `base_port: 7000` explicitly or adopt the new default.

Closes #21, #22.

## Test plan

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (35 tests, 0 failures)
- [ ] Manual: start cluster on macOS with AirPlay Receiver enabled; verify no hang and that explicit `base_port: 7000` now returns `{:port_in_use, 7000, _}` quickly instead of timing out.