### PR TITLE
fix: stop killing "stale" daemons in unmanaged mode

### DIFF
--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -368,13 +368,13 @@ defmodule RedisServerWrapper.Server do
   end
 
   # Daemonized: redis-server forks into background, independent of the BEAM.
+  # No stale-process cleanup here -- in unmanaged mode the caller owns the
+  # lifecycle (instances are intended to outlive this BEAM), and ppid=1 is
+  # the normal state of any live detached redis-server, so a "kill anything
+  # whose pid is in the pidfile" heuristic would silently murder live,
+  # wanted instances. If the port is held, check_port_available returns
+  # {:error, {:port_in_use, ...}} and the caller decides what to do.
   defp start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout) do
-    # Check for stale process from a previous run before wiping the node dir
-    stale_pidfile =
-      Path.join([System.tmp_dir!(), "redis-server-wrapper", "node-#{config.port}", "redis.pid"])
-
-    kill_stale_process(stale_pidfile)
-
     with :ok <- check_port_available(config.bind, config.port) do
       do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout)
     end


### PR DESCRIPTION
## Summary

Follow-up to #23/#26. The ppid=1 staleness gate is fine for managed mode but doesn't discriminate in unmanaged mode: daemonization re-parents to init by definition, so every live detached redis-server has ppid=1 immediately -- a live, wanted instance is indistinguishable from a genuinely orphaned one.

The fix: don't run stale cleanup at all on the unmanaged path. Unmanaged's contract is caller-owns-lifecycle (terminate is a no-op, instances intentionally outlive the BEAM). The wrapper shouldn't unilaterally decide something is stale. With #26's pre-flight bind probe in place, a held port returns \`{:error, {:port_in_use, port, :eaddrinuse}}\` and the caller decides what to do.

Managed mode keeps \`kill_stale_process\`: the ppid=1 check there correctly distinguishes prior-BEAM daemonized cruft from a live managed Port child of the current BEAM.

Closes #27.

## Test plan

- [x] \`mix format --check-formatted\`, \`mix compile --warnings-as-errors\`, \`mix credo --strict\`
- [x] \`mix test\` (35/35 pass)
- [x] Manual repro: two sequential \`Server.start_link(port: 17050, managed: false)\` calls; second returns \`{:error, {:port_in_use, 17050, :eaddrinuse}}\`, first daemon still alive (\`ps -p\` confirms)