### PR TITLE
fix: load stack modules in unmanaged mode

### DIFF
--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -395,7 +395,12 @@ defmodule RedisServerWrapper.Server do
     conf_path = Path.join(node_dir, "redis.conf")
     File.write!(conf_path, Config.to_config_string(config))
 
-    case System.cmd(redis_server_bin, [conf_path], stderr_to_stdout: true) do
+    server_bin_path = System.find_executable(redis_server_bin) || redis_server_bin
+
+    # If using the redis-stack binary, load the Stack modules
+    module_args = detect_stack_modules(server_bin_path)
+
+    case System.cmd(server_bin_path, [conf_path | module_args], stderr_to_stdout: true) do
       {_output, 0} ->
         cli =
           Cli.new(


### PR DESCRIPTION
## Summary
- `do_start_unmanaged` skipped `detect_stack_modules`, so `managed: false` with a redis-stack binary started a vanilla redis with no `--loadmodule` flags.
- Resolve the absolute binary path and pass module args through `System.cmd`, matching `do_start_managed`.

Fixes #29

## Test plan
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix credo --strict`
- [x] `mix test` (35 tests, 0 failures)
- [ ] Manual: `managed: false` with redis-stack binary -> `MODULE LIST` returns loaded modules