### PR TITLE
fix: allow immediate managed Redis restarts

### DIFF
--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -570,7 +570,14 @@ defmodule RedisServerWrapper.Server do
   defp check_port_available(bind, port) do
     case :inet.parse_address(to_charlist(bind)) do
       {:ok, ip} ->
-        case :gen_tcp.listen(port, [:binary, {:ip, ip}, {:active, false}]) do
+        # Match Redis's address-reuse behavior so a recently closed client
+        # connection does not make this preflight report a false :eaddrinuse.
+        case :gen_tcp.listen(port, [
+               :binary,
+               {:ip, ip},
+               {:active, false},
+               {:reuseaddr, true}
+             ]) do
           {:ok, sock} ->
             :gen_tcp.close(sock)
             :ok

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -241,6 +241,26 @@ defmodule RedisServerWrapperTest do
       Server.stop(server)
       Process.sleep(500)
     end
+
+    test "managed server can restart immediately after a client connection" do
+      {:ok, server} = Server.start_link(port: 6414)
+
+      assert {:ok, "OK"} = Server.run(server, ["SET", "restart_key", "restart_val"])
+      assert :ok = Server.stop(server)
+
+      assert {:ok, restarted} = Server.start_link(port: 6414)
+      assert Server.ping(restarted)
+      assert :ok = Server.stop(restarted)
+    end
+
+    test "managed server still rejects a port with a live listener" do
+      {:ok, server} = Server.start_link(port: 6415)
+
+      assert {:error, {:port_in_use, 6415, _reason}} =
+               Server.start(port: 6415)
+
+      assert :ok = Server.stop(server)
+    end
   end
 
   describe "Server forcola mode" do


### PR DESCRIPTION
## What changed

- make the local port preflight use `SO_REUSEADDR`, matching Redis's bind behavior
- add a regression test that performs a real client command, stops the managed server, and immediately restarts it on the same port
- verify that the preflight still rejects a port held by a live listener

## Root cause

The preflight `:gen_tcp.listen/2` probe did not enable address reuse. After a Redis client connection closed, TCP teardown state could make the probe return `:eaddrinuse` even though no process was listening and Redis itself could safely rebind. This made supervised stop/restart flows fail spuriously.

## Impact

Managed Redis instances can now be stopped and restarted immediately on the same port without application-level retries, while genuine port collisions remain protected.

## Validation

- `mix test` — 47 passed
- focused immediate-restart and live-listener regression tests — 2 passed
- `mix compile --force --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`

Closes #38