### PR TITLE
fix: silence optional Forcola compile warning

### DIFF
--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -42,6 +42,9 @@ defmodule RedisServerWrapper.Server do
 
   require Logger
 
+  # Forcola is an optional dependency guarded by forcola_available?/0.
+  @compile {:no_warn_undefined, Forcola.Daemon}
+
   @default_timeout 10_000
 
   defstruct [


### PR DESCRIPTION
## What changed

Declare `Forcola.Daemon` as an intentionally optional compile-time module while retaining the existing runtime availability guard and direct backend call.

## Root cause

The wrapper correctly checked `Code.ensure_loaded?(Forcola.Daemon)` before using the optional backend, but Elixir resolves the direct remote call while compiling a consumer. Consumers that did not install Forcola therefore received an undefined-module warning even when they used the default managed backend.

## Impact

Applications that depend only on `redis_server_wrapper` compile cleanly under `--warnings-as-errors`. The optional backend's runtime behavior is unchanged.

## Validation

- path-based consumer without Forcola compiles with `mix compile --warnings-as-errors`
- absent backend returns `{:error, :forcola_not_available}`
- installed Forcola integration test passes
- `mix compile --force --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`

Closes #45