### PR TITLE
test: enforce 90% behavioral coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
         run: mix dialyzer
 
       - name: Run tests
+        if: matrix.elixir != '1.20' || matrix.otp != '29'
         run: mix test
+
+      - name: Run tests with coverage gate
+        if: matrix.elixir == '1.20' && matrix.otp == '29'
+        run: mix test --cover
 
   docs:
     name: Docs

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -82,7 +82,7 @@ defmodule RedisServerWrapper.Manager do
         |> maybe_put(:maxmemory, maxmemory)
         |> maybe_put(:extra, if(extra != [], do: extra))
 
-      case Server.start_link(server_opts) do
+      case Server.start(server_opts) do
         {:ok, pid} ->
           info = Server.info(pid)
           Server.detach(pid)
@@ -151,7 +151,7 @@ defmodule RedisServerWrapper.Manager do
         loadmodule: loadmodule
       ]
 
-      case Cluster.start_link(cluster_opts) do
+      case Cluster.start(cluster_opts) do
         {:ok, pid} ->
           cluster_info = Cluster.info(pid)
           total_nodes = cluster_info.total_nodes
@@ -230,7 +230,7 @@ defmodule RedisServerWrapper.Manager do
         loadmodule: loadmodule
       ]
 
-      case Sentinel.start_link(sentinel_opts) do
+      case Sentinel.start(sentinel_opts) do
         {:ok, pid} ->
           sen_info = Sentinel.info(pid)
 

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,7 @@ defmodule RedisServerWrapper.MixProject do
       docs: docs(),
       source_url: @source_url,
       homepage_url: @source_url,
+      test_coverage: [summary: [threshold: 90]],
       dialyzer: [plt_file: {:no_warn, "_build/dev/dialyxir_#{System.otp_release()}.plt"}]
     ]
   end

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -146,7 +146,7 @@ defmodule RedisServerWrapperTest do
 
   describe "Server" do
     test "start, ping, run commands, stop" do
-      {:ok, server} = Server.start_link(port: 6400)
+      {:ok, server} = RedisServerWrapper.start_server(port: 6400)
 
       assert Server.ping(server)
       assert Server.alive?(server)
@@ -376,19 +376,96 @@ defmodule RedisServerWrapperTest do
         File.rm_rf!(temp_dir)
       end)
 
-      :ok
+      {:ok, state_file: state_file}
     end
 
     test "basic instances remain running after the launcher GenServer exits" do
-      assert {:ok, instance} =
-               Manager.start_basic(name: "demo-persistent", port: 6430, password: nil)
+      assert {:ok, instance} = Manager.start_basic(port: 6430)
+      on_exit(fn -> Manager.stop(instance.name) end)
 
       assert [_ | _] = instance.pids
-      assert wait_until(fn -> Cli.ping(Cli.new(port: 6430)) end, 5, 200)
-      assert {:ok, %{status: :running}} = Manager.info("demo-persistent")
+      assert instance.name == "redis-basic-1"
+      assert is_binary(instance.password)
+      assert String.length(instance.password) == 16
+      assert instance.url =~ instance.password
 
-      assert :ok = Manager.stop("demo-persistent")
-      assert wait_until(fn -> not Cli.ping(Cli.new(port: 6430)) end, 5, 200)
+      cli = Cli.new(port: 6430, password: instance.password)
+      assert wait_until(fn -> Cli.ping(cli) end, 5, 200)
+      assert {:ok, %{status: :running}} = Manager.info(instance.name)
+
+      assert {:error, {:instance_exists, "redis-basic-1"}} =
+               Manager.start_basic(name: instance.name, port: 6430)
+
+      assert :ok = Manager.stop(instance.name)
+      assert wait_until(fn -> not Cli.ping(cli) end, 5, 200)
+    end
+
+    test "persisted state supports listing, filtering, details, and missing names", %{
+      state_file: state_file
+    } do
+      write_manager_state(state_file, %{
+        "dead-basic" => manager_instance("dead-basic", "basic", "2026-01-01T00:00:00Z"),
+        "dead-cluster" => manager_instance("dead-cluster", "cluster", "2026-01-02T00:00:00Z")
+      })
+
+      assert Enum.map(Manager.list(), & &1.name) == ["dead-basic", "dead-cluster"]
+      assert Enum.map(Manager.list(:cluster), & &1.name) == ["dead-cluster"]
+
+      assert {:ok, info} = Manager.info("dead-basic")
+      assert info.status == :stopped
+      assert info.metadata == %{nested: %{enabled: true}, items: [%{value: 1}]}
+
+      assert {:error, :not_found} = Manager.info("missing")
+      assert {:error, :not_found} = Manager.stop("missing")
+    end
+
+    test "cleanup removes dead persisted instances", %{state_file: state_file} do
+      write_manager_state(state_file, %{
+        "dead-basic" => manager_instance("dead-basic", "basic", "2026-01-01T00:00:00Z"),
+        "dead-cluster" => manager_instance("dead-cluster", "cluster", "2026-01-02T00:00:00Z")
+      })
+
+      assert Manager.cleanup() == {0, 2}
+      assert Manager.list() == []
+    end
+
+    test "stop_all clears persisted instances and counters", %{state_file: state_file} do
+      write_manager_state(
+        state_file,
+        %{"dead-basic" => manager_instance("dead-basic", "basic", "2026-01-01T00:00:00Z")},
+        %{"basic" => 4}
+      )
+
+      assert :ok = Manager.stop_all()
+      assert Manager.list() == []
+    end
+
+    test "topology launchers preserve startup errors" do
+      invalid_modules = [{"/missing/module.so", [:not_a_string]}]
+
+      assert {:error, _reason} =
+               Manager.start_basic(
+                 name: "invalid-basic",
+                 port: 6442,
+                 password: nil,
+                 loadmodule: invalid_modules
+               )
+
+      assert {:error, _reason} =
+               Manager.start_cluster(
+                 name: "invalid-cluster",
+                 base_port: 7440,
+                 password: nil,
+                 loadmodule: invalid_modules
+               )
+
+      assert {:error, _reason} =
+               Manager.start_sentinel(
+                 name: "invalid-sentinel",
+                 master_port: 6480,
+                 password: nil,
+                 loadmodule: invalid_modules
+               )
     end
 
     @tag timeout: 30_000
@@ -451,7 +528,7 @@ defmodule RedisServerWrapperTest do
   describe "Cluster" do
     @tag timeout: 30_000
     test "start 3-master cluster, verify health, stop" do
-      {:ok, cluster} = Cluster.start_link(masters: 3, base_port: 7100)
+      {:ok, cluster} = RedisServerWrapper.start_cluster(masters: 3, base_port: 7100)
 
       assert Cluster.all_alive?(cluster)
       assert wait_until(fn -> Cluster.healthy?(cluster) end)
@@ -460,6 +537,7 @@ defmodule RedisServerWrapperTest do
       assert info.masters == 3
       assert info.total_nodes == 3
       assert length(info.node_addrs) == 3
+      assert Cluster.node_addrs(cluster) == info.node_addrs
 
       addr = Cluster.addr(cluster)
       assert addr == "127.0.0.1:7100"
@@ -488,7 +566,7 @@ defmodule RedisServerWrapperTest do
     @tag timeout: 30_000
     test "start sentinel topology, verify health, stop" do
       {:ok, sentinel} =
-        Sentinel.start_link(
+        RedisServerWrapper.start_sentinel(
           master_port: 6500,
           replicas: 2,
           sentinels: 3
@@ -501,6 +579,13 @@ defmodule RedisServerWrapperTest do
       assert info.replicas == 2
       assert info.sentinels == 3
       assert length(info.sentinel_addrs) == 3
+      assert Sentinel.master_addr(sentinel) == "127.0.0.1:6500"
+
+      assert Sentinel.sentinel_addrs(sentinel) == [
+               "127.0.0.1:26389",
+               "127.0.0.1:26390",
+               "127.0.0.1:26391"
+             ]
 
       assert {:ok, master_info} = Sentinel.poke(sentinel)
       assert master_info["flags"] == "master"
@@ -509,5 +594,28 @@ defmodule RedisServerWrapperTest do
       Sentinel.stop(sentinel)
       Process.sleep(1000)
     end
+  end
+
+  defp write_manager_state(path, instances, counters \\ %{}) do
+    state = %{"instances" => instances, "counters" => counters}
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, JSON.encode!(state))
+  end
+
+  defp manager_instance(name, type, created_at) do
+    %{
+      "name" => name,
+      "type" => type,
+      "created_at" => created_at,
+      "bind" => "127.0.0.1",
+      "ports" => [],
+      "pids" => [99_999_999],
+      "password" => "secret",
+      "url" => "redis://:secret@127.0.0.1:6379",
+      "metadata" => %{
+        "nested" => %{"enabled" => true},
+        "items" => [%{"value" => 1}]
+      }
+    }
   end
 end

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -1,0 +1,166 @@
+defmodule RedisServerWrapperUnitTest do
+  use ExUnit.Case, async: false
+
+  alias RedisServerWrapper.{Cli, Server}
+
+  setup do
+    fixture_dir =
+      Path.join([
+        System.tmp_dir!(),
+        "redis-server-wrapper-tests",
+        "unit-#{System.unique_integer([:positive])}"
+      ])
+
+    File.mkdir_p!(fixture_dir)
+
+    cli_bin =
+      write_executable(
+        fixture_dir,
+        "fake-redis-cli",
+        ~S"""
+        #!/bin/sh
+        args="$*"
+
+        case "$args" in
+          *"--cluster create"*)
+            case "$args" in
+              *"failnode"*) echo "cluster-create-error"; exit 2 ;;
+              *) echo "cluster-created" ;;
+            esac
+            ;;
+          *"CLUSTER INFO"*)
+            case "$args" in
+              *"-h error "*) echo "cluster-info-error"; exit 2 ;;
+              *) printf '# Stats\ncluster_state:ok\norphan\n' ;;
+            esac
+            ;;
+          *"SENTINEL MASTER"*)
+            case "$args" in
+              *"-h error "*) echo "sentinel-error"; exit 2 ;;
+              *) printf 'name\nmymaster\norphan\n' ;;
+            esac
+            ;;
+          *"PING"*)
+            case "$args" in
+              *"-h ready "*) echo "PONG" ;;
+              *"-h loading "*) echo "LOADING dataset" ;;
+              *"-h busy "*) echo "BUSY running" ;;
+              *"-h unexpected "*) echo "NOPE" ;;
+              *) echo "connection-refused"; exit 2 ;;
+            esac
+            ;;
+          *"FAIL"*) echo "failure"; exit 2 ;;
+          *) echo "$args" ;;
+        esac
+        """
+      )
+
+    version_bin =
+      write_executable(fixture_dir, "versioned-server", "#!/bin/sh\necho 'redis v=9.8.7'\n")
+
+    plain_version_bin =
+      write_executable(fixture_dir, "plain-server", "#!/bin/sh\necho 'custom redis build'\n")
+
+    failing_version_bin =
+      write_executable(
+        fixture_dir,
+        "failing-server",
+        "#!/bin/sh\necho 'version failed'; exit 2\n"
+      )
+
+    on_exit(fn -> File.rm_rf!(fixture_dir) end)
+
+    {:ok,
+     cli_bin: cli_bin,
+     version_bin: version_bin,
+     plain_version_bin: plain_version_bin,
+     failing_version_bin: failing_version_bin}
+  end
+
+  test "CLI runs commands, assembles connection options, and raises on errors", %{cli_bin: bin} do
+    assert %Cli{host: "127.0.0.1", port: 6379} = Cli.new()
+
+    cli = Cli.new(bin: bin, host: "ready", port: 6380, password: "secret", tls: true)
+
+    assert {:ok, args} = Cli.run(cli, ["ECHO"])
+    assert args =~ "-h ready -p 6380"
+    assert args =~ "-a secret --no-auth-warning"
+    assert args =~ "--tls ECHO"
+    assert Cli.run!(cli, ["ECHO"]) =~ "--tls ECHO"
+    assert Cli.ping(cli)
+
+    assert {:error, "failure"} = Cli.run(cli, ["FAIL"])
+    assert_raise RuntimeError, ~r/redis-cli error: failure/, fn -> Cli.run!(cli, ["FAIL"]) end
+    refute Cli.ping(%{cli | host: "error"})
+  end
+
+  test "CLI readiness distinguishes ready, transient, failed, and unexpected peers", %{
+    cli_bin: bin
+  } do
+    assert :ok = Cli.wait_for_ready(Cli.new(bin: bin, host: "ready"), 20)
+    assert :ok = Cli.wait_for_ready(Cli.new(bin: bin, host: "ready"))
+
+    assert {:error, {:unexpected_reply, "NOPE"}} =
+             Cli.wait_for_ready(Cli.new(bin: bin, host: "unexpected"), 20)
+
+    assert {:error, :timeout} = Cli.wait_for_ready(Cli.new(bin: bin, host: "loading"), 20)
+    assert {:error, :timeout} = Cli.wait_for_ready(Cli.new(bin: bin, host: "busy"), 20)
+    assert {:error, :timeout} = Cli.wait_for_ready(Cli.new(bin: bin, host: "error"), 20)
+  end
+
+  test "CLI cluster and sentinel helpers parse success and preserve errors", %{cli_bin: bin} do
+    authenticated = Cli.new(bin: bin, password: "secret")
+
+    assert {:ok, "cluster-created"} =
+             Cli.cluster_create(authenticated, ["127.0.0.1:7000"], 1)
+
+    assert {:error, "cluster-create-error"} =
+             Cli.cluster_create(Cli.new(bin: bin), ["failnode"])
+
+    assert {:ok, %{"cluster_state" => "ok", "orphan" => ""}} =
+             Cli.cluster_info(Cli.new(bin: bin, host: "ready"))
+
+    assert {:error, "cluster-info-error"} =
+             Cli.cluster_info(Cli.new(bin: bin, host: "error"))
+
+    assert {:ok, %{"name" => "mymaster", "orphan" => ""}} =
+             Cli.sentinel_master(Cli.new(bin: bin, host: "ready"), "mymaster")
+
+    assert {:error, "sentinel-error"} =
+             Cli.sentinel_master(Cli.new(bin: bin, host: "error"), "mymaster")
+  end
+
+  test "top-level availability and version helpers cover every result shape", context do
+    assert RedisServerWrapper.available?(context.version_bin)
+    refute RedisServerWrapper.available?("definitely-missing-redis-binary")
+
+    assert {:ok, "9.8.7"} = RedisServerWrapper.version(context.version_bin)
+    assert {:ok, "custom redis build"} = RedisServerWrapper.version(context.plain_version_bin)
+    assert {:error, output} = RedisServerWrapper.version(context.failing_version_bin)
+    assert output =~ "version failed"
+
+    assert {:error, {:binary_not_found, "definitely-missing-redis-binary"}} =
+             RedisServerWrapper.version("definitely-missing-redis-binary")
+  end
+
+  test "Server reports missing binaries and managed/unmanaged startup failures" do
+    assert {:error, {:binary_not_found, "missing-redis-server"}} =
+             Server.start(name: :missing_binary_server, redis_server_bin: "missing-redis-server")
+
+    assert {:error, {:binary_not_found, "missing-redis-cli"}} =
+             Server.start(redis_cli_bin: "missing-redis-cli")
+
+    assert {:error, {:server_start_failed, 6440, _status, _output}} =
+             Server.start(port: 6440, managed: false, redis_server_bin: "false")
+
+    assert {:error, {:server_start_timeout, 6441}} =
+             Server.start(port: 6441, managed: true, redis_server_bin: "false", timeout: 20)
+  end
+
+  defp write_executable(dir, name, contents) do
+    path = Path.join(dir, name)
+    File.write!(path, contents)
+    File.chmod!(path, 0o755)
+    path
+  end
+end


### PR DESCRIPTION
## What changed

- raise total line coverage from 80.79% to 90.65% with behavioral tests for the public facade, CLI result parsing/error handling, Manager persistence and lifecycle errors, and Server startup failures
- make Manager use unlinked `start/1` launchers so startup failures return `{:error, reason}` instead of potentially exiting the caller
- explicitly configure the 90% project threshold
- run `mix test --cover` as the Elixir 1.20 / OTP 29 CI lane while retaining the normal suite on Elixir 1.19 / OTP 27

## Coverage

- `RedisServerWrapper`: 100.00%
- `RedisServerWrapper.Cli`: 100.00%
- `RedisServerWrapper.Manager`: 95.48%
- `RedisServerWrapper.Cluster`: 93.13%
- `RedisServerWrapper.Sentinel`: 88.95%
- `RedisServerWrapper.Server`: 81.40%
- total: 90.65%

All 56 tests pass. The new tests reuse existing live topologies where possible and use deterministic fake executables/state files for error paths, avoiding additional fixed sleeps or redundant Redis clusters.

## Validation

- `mix test --cover` — 56 passed, 90.65%, threshold met
- `mix compile --force --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`

Closes #39