### PR TITLE
fix: tolerate missing process utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ end
 ## Prerequisites
 
 You need `redis-server` and `redis-cli` installed and available on your PATH.
+The wrapper uses `kill`, `ps`, and `lsof` for enhanced process inspection and
+best-effort forced cleanup when they are present, but normal server, cluster,
+and sentinel lifecycle operations degrade safely when minimal runtime images
+omit them. Signal-based functions in `RedisServerWrapper.Chaos` still require
+`kill`.
 
 ```bash
 # macOS

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -40,7 +40,7 @@ defmodule RedisServerWrapper.Cluster do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Server}
+  alias RedisServerWrapper.{Cli, OSProcess, Server}
 
   require Logger
 
@@ -320,20 +320,21 @@ defmodule RedisServerWrapper.Cluster do
   end
 
   defp cleanup_ports(ports, bind, redis_cli_bin, password) do
+    unless OSProcess.available?("lsof") do
+      Logger.warning(
+        "lsof is unavailable; Redis Cluster startup will skip best-effort forced port cleanup"
+      )
+    end
+
     Enum.each(ports, fn port ->
       # Try graceful shutdown first
       cli = Cli.new(bin: redis_cli_bin, host: bind, port: port, password: password)
       Cli.shutdown(cli)
 
       # Force kill anything still on this port
-      case System.cmd("lsof", ["-ti", ":#{port}"], stderr_to_stdout: true) do
-        {output, 0} ->
-          output
-          |> String.split("\n", trim: true)
-          |> Enum.each(&System.cmd("kill", ["-9", String.trim(&1)], stderr_to_stdout: true))
-
-        _ ->
-          :ok
+      case OSProcess.pids_on_port(port) do
+        {:ok, pids} -> Enum.each(pids, &OSProcess.signal(&1, :kill))
+        {:error, {:executable_not_found, "lsof"}} -> :ok
       end
     end)
   end

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -19,7 +19,9 @@ defmodule RedisServerWrapper.Manager do
   State is stored at `~/.config/redis-server-wrapper/instances.json`.
   """
 
-  alias RedisServerWrapper.{Cli, Cluster, Sentinel, Server}
+  alias RedisServerWrapper.{Cli, Cluster, OSProcess, Sentinel, Server}
+
+  require Logger
 
   @default_state_file Path.expand("~/.config/redis-server-wrapper/instances.json")
 
@@ -535,47 +537,33 @@ defmodule RedisServerWrapper.Manager do
 
     # Then SIGTERM/SIGKILL any remaining PIDs
     Enum.each(instance.pids, fn pid ->
-      if pid_alive?(pid) do
-        System.cmd("kill", ["-TERM", to_string(pid)], stderr_to_stdout: true)
-      end
+      if OSProcess.alive?(pid), do: OSProcess.signal(pid, :term)
     end)
 
     Process.sleep(500)
 
     Enum.each(instance.pids, fn pid ->
-      if pid_alive?(pid) do
-        System.cmd("kill", ["-9", to_string(pid)], stderr_to_stdout: true)
-      end
+      if OSProcess.alive?(pid), do: OSProcess.signal(pid, :kill)
     end)
   end
 
   defp check_status(instance) do
-    if Enum.any?(instance.pids, &pid_alive?/1) do
+    if Enum.any?(instance.pids, &OSProcess.alive?/1) do
       :running
     else
       :stopped
     end
   end
 
-  defp pid_alive?(pid) when is_integer(pid) do
-    case System.cmd("kill", ["-0", to_string(pid)], stderr_to_stdout: true) do
-      {_, 0} -> true
-      _ -> false
-    end
-  end
-
-  defp pid_alive?(_), do: false
-
   defp find_pids_on_ports(ports) do
-    Enum.flat_map(ports, fn port ->
-      case System.cmd("lsof", ["-ti", ":#{port}"], stderr_to_stdout: true) do
-        {output, 0} ->
-          output
-          |> String.split(~r/\s+/, trim: true)
-          |> Enum.map(&String.to_integer/1)
+    unless OSProcess.available?("lsof") do
+      Logger.warning("lsof is unavailable; sentinel OS PIDs will not be recorded by port")
+    end
 
-        _ ->
-          []
+    Enum.flat_map(ports, fn port ->
+      case OSProcess.pids_on_port(port) do
+        {:ok, pids} -> pids
+        {:error, {:executable_not_found, "lsof"}} -> []
       end
     end)
     |> Enum.uniq()

--- a/lib/redis_server_wrapper/os_process.ex
+++ b/lib/redis_server_wrapper/os_process.ex
@@ -1,0 +1,110 @@
+defmodule RedisServerWrapper.OSProcess do
+  @moduledoc false
+
+  @type signal :: :term | :kill | :stop | :cont
+  @type command_error ::
+          {:executable_not_found, String.t()}
+          | {:signal_failed, signal(), integer(), non_neg_integer(), String.t()}
+
+  @spec available?(String.t()) :: boolean()
+  def available?(executable), do: System.find_executable(executable) != nil
+
+  @spec signal(integer(), signal()) :: :ok | {:error, command_error()}
+  def signal(pid, signal) when is_integer(pid) do
+    case System.find_executable("kill") do
+      nil ->
+        {:error, {:executable_not_found, "kill"}}
+
+      kill ->
+        case System.cmd(kill, [signal_arg(signal), to_string(pid)], stderr_to_stdout: true) do
+          {_output, 0} ->
+            :ok
+
+          {output, status} ->
+            {:error, {:signal_failed, signal, pid, status, String.trim(output)}}
+        end
+    end
+  end
+
+  @spec alive?(integer() | nil) :: boolean()
+  def alive?(nil), do: false
+
+  def alive?(pid) when is_integer(pid) and pid > 0 do
+    case System.find_executable("kill") do
+      nil ->
+        procfs_pid_alive?(pid)
+
+      kill ->
+        case System.cmd(kill, ["-0", to_string(pid)], stderr_to_stdout: true) do
+          {_output, 0} -> true
+          _other -> false
+        end
+    end
+  end
+
+  def alive?(_pid), do: false
+
+  @spec orphaned?(pos_integer()) :: boolean()
+  def orphaned?(pid) when is_integer(pid) and pid > 0 do
+    case System.find_executable("ps") do
+      nil ->
+        procfs_parent_pid(pid) == 1
+
+      ps ->
+        case System.cmd(ps, ["-o", "ppid=", "-p", to_string(pid)], stderr_to_stdout: true) do
+          {output, 0} -> String.trim(output) == "1"
+          _other -> false
+        end
+    end
+  end
+
+  @spec pids_on_port(:inet.port_number()) ::
+          {:ok, [pos_integer()]} | {:error, {:executable_not_found, String.t()}}
+  def pids_on_port(port) when is_integer(port) and port >= 0 and port <= 65_535 do
+    case System.find_executable("lsof") do
+      nil ->
+        {:error, {:executable_not_found, "lsof"}}
+
+      lsof ->
+        case System.cmd(lsof, ["-ti", ":#{port}"], stderr_to_stdout: true) do
+          {output, 0} ->
+            pids =
+              output
+              |> String.split(~r/\s+/, trim: true)
+              |> Enum.flat_map(&parse_pid/1)
+
+            {:ok, pids}
+
+          _other ->
+            {:ok, []}
+        end
+    end
+  end
+
+  defp signal_arg(:term), do: "-TERM"
+  defp signal_arg(:kill), do: "-9"
+  defp signal_arg(:stop), do: "-STOP"
+  defp signal_arg(:cont), do: "-CONT"
+
+  defp procfs_pid_alive?(pid) do
+    File.dir?("/proc") and File.exists?("/proc/#{pid}")
+  end
+
+  defp procfs_parent_pid(pid) do
+    with {:ok, status} <- File.read("/proc/#{pid}/status"),
+         line when is_binary(line) <-
+           Enum.find(String.split(status, "\n"), &String.starts_with?(&1, "PPid:")),
+         {parent_pid, _rest} <- Integer.parse(String.trim_leading(line, "PPid:") |> String.trim()) do
+      parent_pid
+    else
+      _other -> nil
+    end
+  end
+
+  defp parse_pid(value) do
+    case Integer.parse(value) do
+      {pid, ""} when pid > 0 -> [pid]
+      _other -> []
+    end
+  end
+end

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -41,7 +41,7 @@ defmodule RedisServerWrapper.Sentinel do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Server}
+  alias RedisServerWrapper.{Cli, OSProcess, Server}
 
   require Logger
 
@@ -286,17 +286,14 @@ defmodule RedisServerWrapper.Sentinel do
 
     # Stop sentinels first (they're raw OS processes, not GenServers)
     Enum.each(state.sentinel_os_pids, fn pid ->
-      System.cmd("kill", ["-TERM", to_string(pid)], stderr_to_stdout: true)
+      OSProcess.signal(pid, :term)
     end)
 
     Process.sleep(500)
 
     # Force kill any remaining sentinel processes
     Enum.each(state.sentinel_os_pids, fn pid ->
-      case System.cmd("kill", ["-0", to_string(pid)], stderr_to_stdout: true) do
-        {_, 0} -> System.cmd("kill", ["-9", to_string(pid)], stderr_to_stdout: true)
-        _ -> :ok
-      end
+      if OSProcess.alive?(pid), do: OSProcess.signal(pid, :kill)
     end)
 
     # Stop replicas, then master
@@ -447,7 +444,7 @@ defmodule RedisServerWrapper.Sentinel do
 
   defp kill_pids(pids) do
     Enum.each(pids, fn pid ->
-      System.cmd("kill", ["-TERM", to_string(pid)], stderr_to_stdout: true)
+      OSProcess.signal(pid, :term)
     end)
   end
 

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -38,7 +38,7 @@ defmodule RedisServerWrapper.Server do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Config}
+  alias RedisServerWrapper.{Cli, Config, OSProcess}
 
   require Logger
 
@@ -202,7 +202,7 @@ defmodule RedisServerWrapper.Server do
   end
 
   def handle_call(:alive?, _from, state) do
-    {:reply, pid_alive?(state.pid), state}
+    {:reply, OSProcess.alive?(state.pid), state}
   end
 
   def handle_call({:run, args}, _from, state) do
@@ -302,12 +302,12 @@ defmodule RedisServerWrapper.Server do
     # Force kill if still alive.
     # Use kill on the process group (-pid) to also catch child processes.
     # This handles redis-stack-server (bash wrapper) which spawns a child redis-server.
-    if state.pid && pid_alive?(state.pid) do
+    if state.pid && OSProcess.alive?(state.pid) do
       Logger.warning("redis-server PID #{state.pid} still alive after SHUTDOWN, sending SIGKILL")
       # Kill the process group (negative PID) to get wrapper + child
-      System.cmd("kill", ["-9", "-#{state.pid}"], stderr_to_stdout: true)
+      warn_if_signal_unavailable(OSProcess.signal(-state.pid, :kill), state.pid)
       # Also try the individual PID in case process group kill didn't work
-      System.cmd("kill", ["-9", to_string(state.pid)], stderr_to_stdout: true)
+      warn_if_signal_unavailable(OSProcess.signal(state.pid, :kill), state.pid)
     end
 
     # Extra safety: find and kill any redis-server on our port
@@ -610,25 +610,18 @@ defmodule RedisServerWrapper.Server do
     # a managed Port child of some BEAM -- possibly our own -- and we
     # must not kill it, or we'd murder a server that was just started on
     # the same port by the same or a sibling process.
-    if pid_alive?(stale_pid) and orphaned?(stale_pid) do
+    if OSProcess.alive?(stale_pid) and OSProcess.orphaned?(stale_pid) do
       Logger.warning("Killing stale redis-server process #{stale_pid}")
-      System.cmd("kill", [to_string(stale_pid)], stderr_to_stdout: true)
+      warn_if_signal_unavailable(OSProcess.signal(stale_pid, :term), stale_pid)
       Process.sleep(500)
       force_kill_if_alive(stale_pid)
     end
   end
 
-  defp orphaned?(pid) do
-    case System.cmd("ps", ["-o", "ppid=", "-p", to_string(pid)], stderr_to_stdout: true) do
-      {out, 0} -> String.trim(out) == "1"
-      _ -> false
-    end
-  end
-
   defp force_kill_if_alive(pid) do
-    if pid_alive?(pid) do
+    if OSProcess.alive?(pid) do
       Logger.warning("Stale PID #{pid} still alive, sending SIGKILL")
-      System.cmd("kill", ["-9", to_string(pid)], stderr_to_stdout: true)
+      warn_if_signal_unavailable(OSProcess.signal(pid, :kill), pid)
     end
   end
 
@@ -655,15 +648,6 @@ defmodule RedisServerWrapper.Server do
     end
   end
 
-  defp pid_alive?(nil), do: false
-
-  defp pid_alive?(pid) do
-    case System.cmd("kill", ["-0", to_string(pid)], stderr_to_stdout: true) do
-      {_, 0} -> true
-      _ -> false
-    end
-  end
-
   # Stop the linked Forcola.Daemon, triggering its group-kill teardown. The
   # daemon may already be gone (redis-server exited on its own), so tolerate a
   # :noproc exit rather than crashing the terminating GenServer.
@@ -684,22 +668,29 @@ defmodule RedisServerWrapper.Server do
   # Kill any redis-server process listening on a specific port.
   # This handles orphaned processes from wrapper scripts (redis-stack-server).
   defp kill_by_port(port) when is_integer(port) do
-    case System.cmd("lsof", ["-ti", ":#{port}"], stderr_to_stdout: true) do
-      {output, 0} ->
-        output
-        |> String.split("\n", trim: true)
-        |> Enum.each(fn pid_str ->
-          System.cmd("kill", ["-9", String.trim(pid_str)], stderr_to_stdout: true)
+    case OSProcess.pids_on_port(port) do
+      {:ok, pids} ->
+        Enum.each(pids, fn pid ->
+          warn_if_signal_unavailable(OSProcess.signal(pid, :kill), pid)
         end)
 
-      _ ->
-        :ok
+      {:error, {:executable_not_found, "lsof"}} ->
+        Logger.warning(
+          "lsof is unavailable; skipping best-effort process cleanup for Redis port #{port}"
+        )
     end
-  rescue
-    _ -> :ok
   end
 
   defp kill_by_port(_), do: :ok
+
+  defp warn_if_signal_unavailable(
+         {:error, {:executable_not_found, "kill"}},
+         pid
+       ) do
+    Logger.warning("kill is unavailable; unable to signal Redis process #{pid}")
+  end
+
+  defp warn_if_signal_unavailable(_result, _pid), do: :ok
 
   # Detect Redis Stack modules (RedisJSON, RediSearch, etc.) if we're using
   # the redis-stack binary. Returns command-line args like

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -1,7 +1,9 @@
 defmodule RedisServerWrapperUnitTest do
   use ExUnit.Case, async: false
 
-  alias RedisServerWrapper.{Cli, Server}
+  import ExUnit.CaptureLog
+
+  alias RedisServerWrapper.{Cli, Cluster, OSProcess, Server}
 
   setup do
     fixture_dir =
@@ -71,6 +73,7 @@ defmodule RedisServerWrapperUnitTest do
     on_exit(fn -> File.rm_rf!(fixture_dir) end)
 
     {:ok,
+     fixture_dir: fixture_dir,
      cli_bin: cli_bin,
      version_bin: version_bin,
      plain_version_bin: plain_version_bin,
@@ -157,10 +160,114 @@ defmodule RedisServerWrapperUnitTest do
              Server.start(port: 6441, managed: true, redis_server_bin: "false", timeout: 20)
   end
 
+  test "OS process helpers normalize executable results", %{fixture_dir: fixture_dir} do
+    write_executable(
+      fixture_dir,
+      "kill",
+      ~S"""
+      #!/bin/sh
+      if [ "$2" = "123" ]; then
+        exit 0
+      fi
+
+      echo "signal failed"
+      exit 2
+      """
+    )
+
+    write_executable(
+      fixture_dir,
+      "lsof",
+      "#!/bin/sh\nprintf '123\\ninvalid\\n456\\n'\n"
+    )
+
+    write_executable(
+      fixture_dir,
+      "ps",
+      ~S"""
+      #!/bin/sh
+      if [ "$4" = "123" ]; then
+        echo "1"
+      else
+        echo "42"
+      fi
+      """
+    )
+
+    original_path = System.get_env("PATH")
+    on_exit(fn -> restore_path(original_path) end)
+    System.put_env("PATH", fixture_dir)
+
+    assert OSProcess.available?("kill")
+    assert :ok = OSProcess.signal(123, :term)
+    assert :ok = OSProcess.signal(123, :kill)
+    assert :ok = OSProcess.signal(123, :stop)
+    assert :ok = OSProcess.signal(123, :cont)
+
+    assert {:error, {:signal_failed, :term, 999, 2, "signal failed"}} =
+             OSProcess.signal(999, :term)
+
+    assert OSProcess.alive?(123)
+    refute OSProcess.alive?(999)
+    refute OSProcess.alive?(nil)
+    refute OSProcess.alive?(-1)
+    assert OSProcess.orphaned?(123)
+    refute OSProcess.orphaned?(999)
+    assert {:ok, [123, 456]} = OSProcess.pids_on_port(6490)
+  end
+
+  test "missing kill and lsof do not crash teardown or cluster pre-cleanup", %{
+    cli_bin: cli_bin
+  } do
+    redis_server_bin = System.find_executable("redis-server")
+    redis_cli_bin = System.find_executable("redis-cli")
+    false_bin = System.find_executable("false")
+    original_path = System.get_env("PATH")
+    empty_path = Path.join(System.tmp_dir!(), "redis-server-wrapper-no-process-tools")
+    File.mkdir_p!(empty_path)
+
+    on_exit(fn -> restore_path(original_path) end)
+
+    System.put_env("PATH", empty_path)
+
+    refute OSProcess.available?("kill")
+    refute OSProcess.available?("lsof")
+    assert {:error, {:executable_not_found, "kill"}} = OSProcess.signal(1, :term)
+    assert {:error, {:executable_not_found, "lsof"}} = OSProcess.pids_on_port(6490)
+    assert is_boolean(OSProcess.alive?(String.to_integer(System.pid())))
+    assert is_boolean(OSProcess.orphaned?(String.to_integer(System.pid())))
+
+    log =
+      capture_log(fn ->
+        assert {:ok, server} =
+                 Server.start_link(
+                   port: 6490,
+                   redis_server_bin: redis_server_bin,
+                   redis_cli_bin: redis_cli_bin
+                 )
+
+        assert :ok = Server.stop(server)
+
+        assert {:error, {:node_start_failed, 7490, _reason}} =
+                 Cluster.start(
+                   masters: 1,
+                   base_port: 7490,
+                   timeout: 20,
+                   redis_server_bin: false_bin,
+                   redis_cli_bin: cli_bin
+                 )
+      end)
+
+    assert log =~ "lsof is unavailable"
+  end
+
   defp write_executable(dir, name, contents) do
     path = Path.join(dir, name)
     File.write!(path, contents)
     File.chmod!(path, 0o755)
     path
   end
+
+  defp restore_path(nil), do: System.delete_env("PATH")
+  defp restore_path(path), do: System.put_env("PATH", path)
 end


### PR DESCRIPTION
## Summary

- route normal lifecycle process inspection and signaling through a safe OS-process helper
- fall back to Linux procfs when kill or ps is unavailable
- skip best-effort lsof cleanup with an actionable warning instead of raising :enoent
- cover standalone teardown and cluster pre-cleanup with a PATH that contains none of the optional tools
- document which utilities are optional and that Chaos signal functions still require kill

## Validation

- 58 tests passed
- 90.90% total coverage
- mix compile --force --warnings-as-errors
- mix format --check-formatted
- mix credo --strict
- mix dialyzer

Closes #49