### PR TITLE
fix: make topology cleanup ownership-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ end
 ## Prerequisites
 
 You need `redis-server` and `redis-cli` installed and available on your PATH.
-The wrapper uses `kill`, `ps`, and `lsof` for enhanced process inspection and
-best-effort forced cleanup when they are present, but normal server, cluster,
-and sentinel lifecycle operations degrade safely when minimal runtime images
-omit them. Signal-based functions in `RedisServerWrapper.Chaos` still require
+The wrapper uses `kill` and `lsof` for process inspection and management
+when they are present, but normal server, cluster, and sentinel lifecycle
+operations degrade safely when minimal runtime images omit them. Occupied ports
+fail startup; the wrapper does not shut down or signal an existing listener to
+claim a port. Signal-based functions in `RedisServerWrapper.Chaos` still require
 `kill`.
 
 ```bash

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -40,7 +40,7 @@ defmodule RedisServerWrapper.Cluster do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, OSProcess, Server}
+  alias RedisServerWrapper.{Cli, Server}
 
   require Logger
 
@@ -131,14 +131,10 @@ defmodule RedisServerWrapper.Cluster do
     extra = Keyword.get(opts, :extra, [])
     managed = Keyword.get(opts, :managed, true)
 
-    total_nodes = masters * (1 + replicas)
-    ports = Enum.map(0..(total_nodes - 1), &(base_port + &1))
-
-    # Pre-cleanup: try to shut down anything on these ports
-    cleanup_ports(ports, bind, redis_cli_bin, password)
-    Process.sleep(500)
-
-    node_opts = %{
+    settings = %{
+      masters: masters,
+      replicas_per_master: replicas,
+      base_port: base_port,
       bind: bind,
       password: password,
       redis_server_bin: redis_server_bin,
@@ -150,38 +146,9 @@ defmodule RedisServerWrapper.Cluster do
       managed: managed
     }
 
-    # Start each node as a Server GenServer
-    case start_nodes(ports, node_opts) do
-      {:ok, node_pids} ->
-        # Form the cluster
-        seed_cli = Cli.new(bin: redis_cli_bin, host: bind, port: base_port, password: password)
-        node_addr_list = Enum.map(ports, &"#{bind}:#{&1}")
-
-        case Cli.cluster_create(seed_cli, node_addr_list, replicas) do
-          {:ok, _output} ->
-            # Wait for cluster convergence
-            Process.sleep(2000)
-
-            state = %__MODULE__{
-              masters: masters,
-              replicas_per_master: replicas,
-              base_port: base_port,
-              bind: bind,
-              password: password,
-              redis_cli_bin: redis_cli_bin,
-              node_pids: node_pids
-            }
-
-            {:ok, state}
-
-          {:error, reason} ->
-            # Rollback: stop all nodes
-            Enum.each(node_pids, &Server.stop/1)
-            {:stop, {:cluster_create_failed, reason}}
-        end
-
-      {:error, reason} ->
-        {:stop, reason}
+    case validate_options(settings) do
+      :ok -> start_validated_cluster(settings)
+      {:error, reason} -> {:stop, reason}
     end
   end
 
@@ -283,6 +250,66 @@ defmodule RedisServerWrapper.Cluster do
   # Internal
   # -------------------------------------------------------------------
 
+  defp start_validated_cluster(settings) do
+    total_nodes = settings.masters * (1 + settings.replicas_per_master)
+    ports = ports_from(settings.base_port, total_nodes)
+
+    node_opts =
+      Map.take(settings, [
+        :bind,
+        :password,
+        :redis_server_bin,
+        :redis_cli_bin,
+        :timeout,
+        :cluster_node_timeout,
+        :loadmodule,
+        :extra,
+        :managed
+      ])
+
+    # Server startup fails closed if a requested port is already occupied;
+    # Cluster never shuts down or signals an existing listener to claim it.
+    case start_nodes(ports, node_opts) do
+      {:ok, node_pids} -> form_cluster(node_pids, ports, settings)
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  defp form_cluster(node_pids, ports, settings) do
+    seed_cli =
+      Cli.new(
+        bin: settings.redis_cli_bin,
+        host: settings.bind,
+        port: settings.base_port,
+        password: settings.password
+      )
+
+    node_addr_list = Enum.map(ports, &"#{settings.bind}:#{&1}")
+
+    case Cli.cluster_create(seed_cli, node_addr_list, settings.replicas_per_master) do
+      {:ok, _output} ->
+        # Wait for cluster convergence
+        Process.sleep(2000)
+
+        state = %__MODULE__{
+          masters: settings.masters,
+          replicas_per_master: settings.replicas_per_master,
+          base_port: settings.base_port,
+          bind: settings.bind,
+          password: settings.password,
+          redis_cli_bin: settings.redis_cli_bin,
+          node_pids: node_pids
+        }
+
+        {:ok, state}
+
+      {:error, reason} ->
+        # Rollback: stop all nodes
+        Enum.each(node_pids, &Server.stop/1)
+        {:stop, {:cluster_create_failed, reason}}
+    end
+  end
+
   defp start_nodes(ports, node_opts) do
     results =
       Enum.reduce_while(ports, {:ok, []}, fn port, {:ok, acc} ->
@@ -302,9 +329,6 @@ defmodule RedisServerWrapper.Cluster do
             save: :disabled
           ] ++ extra_to_opts(node_opts.extra)
 
-        # Clean any stale cluster config from previous runs
-        clean_node_dir(port)
-
         case Server.start_link(opts) do
           {:ok, pid} ->
             {:cont, {:ok, acc ++ [pid]}}
@@ -317,26 +341,6 @@ defmodule RedisServerWrapper.Cluster do
       end)
 
     results
-  end
-
-  defp cleanup_ports(ports, bind, redis_cli_bin, password) do
-    unless OSProcess.available?("lsof") do
-      Logger.warning(
-        "lsof is unavailable; Redis Cluster startup will skip best-effort forced port cleanup"
-      )
-    end
-
-    Enum.each(ports, fn port ->
-      # Try graceful shutdown first
-      cli = Cli.new(bin: redis_cli_bin, host: bind, port: port, password: password)
-      Cli.shutdown(cli)
-
-      # Force kill anything still on this port
-      case OSProcess.pids_on_port(port) do
-        {:ok, pids} -> Enum.each(pids, &OSProcess.signal(&1, :kill))
-        {:error, {:executable_not_found, "lsof"}} -> :ok
-      end
-    end)
   end
 
   defp seed_cli(state) do
@@ -370,33 +374,47 @@ defmodule RedisServerWrapper.Cluster do
     end)
   end
 
-  # Remove stale cluster config files from a node's data directory.
-  # These persist across runs and cause "Node is not empty" errors
-  # when trying to create a new cluster.
-  defp clean_node_dir(port) do
-    # Clean our temp dir
-    base = System.tmp_dir!()
-    node_dir = Path.join([base, "redis-server-wrapper", "node-#{port}"])
-    clean_cluster_files(node_dir, port)
+  defp validate_options(settings) do
+    with :ok <- positive_integer(:masters, settings.masters),
+         :ok <-
+           non_negative_integer(:replicas_per_master, settings.replicas_per_master),
+         :ok <- valid_port(:base_port, settings.base_port),
+         :ok <- positive_integer(:timeout, settings.timeout),
+         :ok <- positive_integer(:cluster_node_timeout, settings.cluster_node_timeout) do
+      total_nodes = settings.masters * (1 + settings.replicas_per_master)
+      last_data_port = settings.base_port + total_nodes - 1
+      first_bus_port = settings.base_port + 10_000
+      last_bus_port = last_data_port + 10_000
 
-    # Also clean redis-stack-server's default data dir.
-    # redis-stack-server writes cluster config to its own dir regardless of
-    # what `dir` is set to in our config.
-    stack_dir = "/opt/homebrew/var/db/redis-stack"
-    clean_cluster_files(stack_dir, port)
-  end
+      cond do
+        last_data_port > 65_535 ->
+          {:error, {:invalid_port_range, :cluster_nodes, settings.base_port, last_data_port}}
 
-  defp clean_cluster_files(dir, port) do
-    if File.dir?(dir) do
-      ["nodes-#{port}.conf", "nodes-*.conf", "dump.rdb", "appendonly.aof", "appendonlydir"]
-      |> Enum.flat_map(&Path.wildcard(Path.join(dir, &1)))
-      |> Enum.each(&remove_path/1)
+        last_data_port >= first_bus_port ->
+          {:error,
+           {:overlapping_port_ranges, :cluster_nodes, settings.base_port, last_data_port,
+            :cluster_bus, first_bus_port, last_bus_port}}
+
+        last_bus_port > 65_535 ->
+          {:error, {:invalid_port_range, :cluster_bus, first_bus_port, last_bus_port}}
+
+        true ->
+          :ok
+      end
     end
   end
 
-  defp remove_path(path) do
-    if File.dir?(path), do: File.rm_rf!(path), else: File.rm(path)
-  end
+  defp positive_integer(_key, value) when is_integer(value) and value > 0, do: :ok
+  defp positive_integer(key, value), do: {:error, {:invalid_option, key, value}}
+
+  defp non_negative_integer(_key, value) when is_integer(value) and value >= 0, do: :ok
+  defp non_negative_integer(key, value), do: {:error, {:invalid_option, key, value}}
+
+  defp valid_port(_key, value) when is_integer(value) and value in 1..65_535, do: :ok
+  defp valid_port(key, value), do: {:error, {:invalid_option, key, value}}
+
+  defp ports_from(_base_port, 0), do: []
+  defp ports_from(base_port, count), do: Enum.map(0..(count - 1), &(base_port + &1))
 
   defp extract_gen_opts(opts) do
     case Keyword.pop(opts, :name) do

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -201,6 +201,7 @@ defmodule RedisServerWrapper.Manager do
     * `:master_port` - master port (default: 6390)
     * `:replicas` - number of replicas (default: 2)
     * `:sentinels` - number of sentinels (default: 3)
+    * `:quorum` - Sentinel quorum (default: min(2, sentinels))
     * `:sentinel_base_port` - starting sentinel port (default: 26389)
     * `:password` - Redis password (auto-generated if omitted)
     * `:bind` - bind address (default: "127.0.0.1")
@@ -214,6 +215,7 @@ defmodule RedisServerWrapper.Manager do
     master_port = Keyword.get(opts, :master_port, 6390)
     num_replicas = Keyword.get(opts, :replicas, 2)
     num_sentinels = Keyword.get(opts, :sentinels, 3)
+    quorum = Keyword.get(opts, :quorum, min(2, num_sentinels))
     sentinel_base_port = Keyword.get(opts, :sentinel_base_port, 26_389)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
     loadmodule = Keyword.get(opts, :loadmodule, [])
@@ -225,6 +227,7 @@ defmodule RedisServerWrapper.Manager do
         master_port: master_port,
         replicas: num_replicas,
         sentinels: num_sentinels,
+        quorum: quorum,
         sentinel_base_port: sentinel_base_port,
         bind: bind,
         password: password,
@@ -243,9 +246,9 @@ defmodule RedisServerWrapper.Manager do
 
           all_redis_ports =
             [master_port] ++
-              Enum.map(0..(num_replicas - 1), &(replica_base_port + &1))
+              ports_from(replica_base_port, num_replicas)
 
-          sentinel_ports = Enum.map(0..(num_sentinels - 1), &(sentinel_base_port + &1))
+          sentinel_ports = ports_from(sentinel_base_port, num_sentinels)
 
           # Read OS pids from pidfiles
           redis_pids =
@@ -338,7 +341,7 @@ defmodule RedisServerWrapper.Manager do
   @doc """
   Stops a named instance by sending SHUTDOWN to all its processes.
   """
-  @spec stop(String.t()) :: :ok | {:error, :not_found}
+  @spec stop(String.t()) :: :ok | {:error, term()}
   def stop(name) do
     state = load_state()
 
@@ -347,29 +350,48 @@ defmodule RedisServerWrapper.Manager do
         {:error, :not_found}
 
       instance ->
-        stop_instance_processes(instance)
-        save_state(remove_instance(state, name))
-        IO.puts("Stopped #{name}")
-        :ok
+        case stop_instance_processes(instance) do
+          :ok ->
+            save_state(remove_instance(state, name))
+            IO.puts("Stopped #{name}")
+            :ok
+
+          {:error, reason} ->
+            {:error, reason}
+        end
     end
   end
 
   @doc """
   Stops all tracked instances.
   """
-  @spec stop_all() :: :ok
+  @spec stop_all() :: :ok | {:error, {:instances_not_stopped, map()}}
   def stop_all do
     state = load_state()
 
-    state.instances
-    |> Map.values()
-    |> Enum.each(fn instance ->
-      stop_instance_processes(instance)
-      IO.puts("Stopped #{instance.name}")
-    end)
+    {remaining, failures} =
+      Enum.reduce(state.instances, {%{}, %{}}, fn {name, instance}, {remaining, failures} ->
+        case stop_instance_processes(instance) do
+          :ok ->
+            IO.puts("Stopped #{instance.name}")
+            {remaining, failures}
 
-    save_state(%{state | instances: %{}, counters: %{}})
-    :ok
+          {:error, reason} ->
+            {Map.put(remaining, name, instance), Map.put(failures, name, reason)}
+        end
+      end)
+
+    save_state(%{
+      state
+      | instances: remaining,
+        counters: if(remaining == %{}, do: %{}, else: state.counters)
+    })
+
+    if failures == %{} do
+      :ok
+    else
+      {:error, {:instances_not_stopped, failures}}
+    end
   end
 
   @doc """
@@ -527,24 +549,82 @@ defmodule RedisServerWrapper.Manager do
   # -------------------------------------------------------------------
 
   defp stop_instance_processes(instance) do
-    # First try graceful SHUTDOWN via redis-cli on each port
-    Enum.each(instance.ports, fn port ->
-      cli = Cli.new(host: instance.bind, port: port, password: instance.password)
-      Cli.shutdown(cli)
-    end)
+    case owned_listeners(instance) do
+      {:ok, listeners} -> stop_owned_instance(instance, listeners)
+      {:error, _reason} = error -> error
+    end
+  end
 
+  defp stop_owned_instance(instance, listeners) when map_size(listeners) == 0 do
+    if Enum.any?(instance.pids, &OSProcess.alive?/1) do
+      {:error, {:process_ownership_not_verified, instance.name, instance.pids}}
+    else
+      :ok
+    end
+  end
+
+  defp stop_owned_instance(instance, listeners) do
+    gracefully_stop_owned_listeners(instance, listeners)
     Process.sleep(1000)
 
-    # Then SIGTERM/SIGKILL any remaining PIDs
-    Enum.each(instance.pids, fn pid ->
-      if OSProcess.alive?(pid), do: OSProcess.signal(pid, :term)
-    end)
+    with :ok <- signal_owned_listeners(instance, :term),
+         _ <- Process.sleep(500),
+         :ok <- signal_owned_listeners(instance, :kill) do
+      verify_instance_stopped(instance)
+    end
+  end
 
-    Process.sleep(500)
+  defp verify_instance_stopped(instance) do
+    case Enum.filter(instance.pids, &OSProcess.alive?/1) do
+      [] -> :ok
+      remaining -> {:error, {:processes_still_running, instance.name, remaining}}
+    end
+  end
 
-    Enum.each(instance.pids, fn pid ->
-      if OSProcess.alive?(pid), do: OSProcess.signal(pid, :kill)
+  defp owned_listeners(instance) do
+    Enum.reduce_while(
+      instance.ports,
+      {:ok, %{}},
+      &collect_owned_listener(&1, &2, instance)
+    )
+  end
+
+  defp collect_owned_listener(port, {:ok, listeners}, instance) do
+    case OSProcess.pids_on_port(port) do
+      {:ok, port_pids} ->
+        owned_pids = Enum.filter(port_pids, &(&1 in instance.pids))
+        {:cont, {:ok, maybe_put_listener(listeners, port, owned_pids)}}
+
+      {:error, reason} ->
+        {:halt, {:error, {:process_ownership_not_verified, instance.name, reason}}}
+    end
+  end
+
+  defp maybe_put_listener(listeners, _port, []), do: listeners
+  defp maybe_put_listener(listeners, port, pids), do: Map.put(listeners, port, pids)
+
+  defp gracefully_stop_owned_listeners(instance, listeners) do
+    Enum.each(Map.keys(listeners), fn port ->
+      cli = Cli.new(host: instance.bind, port: port, password: instance.password)
+      _result = Cli.run(cli, ["SHUTDOWN", "NOSAVE"])
     end)
+  end
+
+  defp signal_owned_listeners(instance, signal) do
+    with {:ok, listeners} <- owned_listeners(instance) do
+      listeners
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.uniq()
+      |> Enum.reduce_while(:ok, &signal_listener(&1, signal, &2))
+    end
+  end
+
+  defp signal_listener(pid, signal, :ok) do
+    case OSProcess.signal(pid, signal) do
+      :ok -> {:cont, :ok}
+      {:error, reason} -> {:halt, {:error, reason}}
+    end
   end
 
   defp check_status(instance) do
@@ -582,6 +662,9 @@ defmodule RedisServerWrapper.Manager do
       {:error, _} -> nil
     end
   end
+
+  defp ports_from(_base_port, 0), do: []
+  defp ports_from(base_port, count), do: Enum.map(0..(count - 1), &(base_port + &1))
 
   # -------------------------------------------------------------------
   # URL building

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -116,7 +116,14 @@ defmodule RedisServerWrapper.Sentinel do
     master_name = Keyword.get(opts, :master_name, "mymaster")
     master_port = Keyword.get(opts, :master_port, 6390)
     num_replicas = Keyword.get(opts, :replicas, 2)
-    replica_base_port = Keyword.get(opts, :replica_base_port, master_port + 1)
+
+    replica_base_port =
+      case Keyword.fetch(opts, :replica_base_port) do
+        {:ok, port} -> port
+        :error when is_integer(master_port) -> master_port + 1
+        :error -> master_port
+      end
+
     num_sentinels = Keyword.get(opts, :sentinels, 3)
     sentinel_base_port = Keyword.get(opts, :sentinel_base_port, 26_389)
     quorum = Keyword.get(opts, :quorum, 2)
@@ -133,15 +140,6 @@ defmodule RedisServerWrapper.Sentinel do
     loadmodule = Keyword.get(opts, :loadmodule, [])
     managed = Keyword.get(opts, :managed, true)
 
-    all_ports =
-      [master_port] ++
-        Enum.map(0..(num_replicas - 1), &(replica_base_port + &1)) ++
-        Enum.map(0..(num_sentinels - 1), &(sentinel_base_port + &1))
-
-    # Pre-cleanup
-    cleanup_ports(all_ports, bind, redis_cli_bin, password)
-    Process.sleep(500)
-
     node_opts = %{
       bind: bind,
       password: password,
@@ -152,7 +150,20 @@ defmodule RedisServerWrapper.Sentinel do
       managed: managed
     }
 
-    with {:ok, master_pid} <- start_master(master_port, node_opts),
+    validation_settings = %{
+      master_port: master_port,
+      replicas: num_replicas,
+      replica_base_port: replica_base_port,
+      sentinels: num_sentinels,
+      sentinel_base_port: sentinel_base_port,
+      quorum: quorum,
+      down_after_ms: down_after_ms,
+      failover_timeout_ms: failover_timeout_ms,
+      timeout: timeout
+    }
+
+    with :ok <- validate_options(validation_settings),
+         {:ok, master_pid} <- start_master(master_port, node_opts),
          {:ok, replica_pids} <-
            start_replicas(num_replicas, replica_base_port, master_port, node_opts),
          # Let replication link up
@@ -175,7 +186,7 @@ defmodule RedisServerWrapper.Sentinel do
       # Wait for sentinel discovery
       Process.sleep(2000)
 
-      sentinel_ports = Enum.map(0..(num_sentinels - 1), &(sentinel_base_port + &1))
+      sentinel_ports = ports_from(sentinel_base_port, num_sentinels)
 
       state = %__MODULE__{
         master_name: master_name,
@@ -487,12 +498,65 @@ defmodule RedisServerWrapper.Sentinel do
     end
   end
 
-  defp cleanup_ports(ports, bind, redis_cli_bin, password) do
-    Enum.each(ports, fn port ->
-      cli = Cli.new(bin: redis_cli_bin, host: bind, port: port, password: password)
-      Cli.shutdown(cli)
-    end)
+  defp validate_options(settings) do
+    with :ok <- valid_port(:master_port, settings.master_port),
+         :ok <- non_negative_integer(:replicas, settings.replicas),
+         :ok <- positive_integer(:sentinels, settings.sentinels),
+         :ok <- valid_port(:sentinel_base_port, settings.sentinel_base_port),
+         :ok <- positive_integer(:quorum, settings.quorum),
+         :ok <- quorum_within_sentinel_count(settings.quorum, settings.sentinels),
+         :ok <- positive_integer(:down_after_ms, settings.down_after_ms),
+         :ok <- positive_integer(:failover_timeout_ms, settings.failover_timeout_ms),
+         :ok <- positive_integer(:timeout, settings.timeout),
+         :ok <-
+           valid_port_span(:replicas, settings.replica_base_port, settings.replicas),
+         :ok <-
+           valid_port_span(:sentinels, settings.sentinel_base_port, settings.sentinels) do
+      all_ports =
+        [settings.master_port] ++
+          ports_from(settings.replica_base_port, settings.replicas) ++
+          ports_from(settings.sentinel_base_port, settings.sentinels)
+
+      if MapSet.size(MapSet.new(all_ports)) == length(all_ports) do
+        :ok
+      else
+        {:error, {:overlapping_ports, all_ports}}
+      end
+    end
   end
+
+  defp positive_integer(_key, value) when is_integer(value) and value > 0, do: :ok
+  defp positive_integer(key, value), do: {:error, {:invalid_option, key, value}}
+
+  defp non_negative_integer(_key, value) when is_integer(value) and value >= 0, do: :ok
+  defp non_negative_integer(key, value), do: {:error, {:invalid_option, key, value}}
+
+  defp valid_port(_key, value) when is_integer(value) and value in 1..65_535, do: :ok
+  defp valid_port(key, value), do: {:error, {:invalid_option, key, value}}
+
+  defp quorum_within_sentinel_count(quorum, sentinels) when quorum <= sentinels, do: :ok
+
+  defp quorum_within_sentinel_count(quorum, sentinels),
+    do: {:error, {:invalid_quorum, quorum, sentinels}}
+
+  defp valid_port_span(_key, _base_port, 0), do: :ok
+
+  defp valid_port_span(key, base_port, count)
+       when is_integer(base_port) and base_port in 1..65_535 do
+    last_port = base_port + count - 1
+
+    if last_port <= 65_535 do
+      :ok
+    else
+      {:error, {:invalid_port_range, key, base_port, last_port}}
+    end
+  end
+
+  defp valid_port_span(key, base_port, _count),
+    do: {:error, {:invalid_option, :"#{key}_base_port", base_port}}
+
+  defp ports_from(_base_port, 0), do: []
+  defp ports_from(base_port, count), do: Enum.map(0..(count - 1), &(base_port + &1))
 
   defp detach_servers(servers) do
     Enum.reduce_while(servers, :ok, fn server, :ok ->

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -290,28 +290,33 @@ defmodule RedisServerWrapper.Server do
       "RedisServerWrapper.Server terminating, sending SHUTDOWN NOSAVE to port #{state.config.port}"
     )
 
-    Cli.shutdown(state.cli)
+    shutdown_if_owned(state)
     # Give it a moment to shut down
     Process.sleep(500)
+
+    managed_pid_owned = managed_port_owns_pid?(state.port_ref, state.pid)
 
     # Close the port if managed
     if state.port_ref && Port.info(state.port_ref) != nil do
       Port.close(state.port_ref)
     end
 
-    # Force kill if still alive.
-    # Use kill on the process group (-pid) to also catch child processes.
-    # This handles redis-stack-server (bash wrapper) which spawns a child redis-server.
-    if state.pid && OSProcess.alive?(state.pid) do
+    force_kill_pid =
+      cond do
+        managed_pid_owned -> state.pid
+        is_nil(state.port_ref) and pid_owns_port?(state.pid, state.config.port) -> state.pid
+        true -> nil
+      end
+
+    # Force kill only when ownership was re-established immediately before the
+    # signal. Use the process group to also catch children of a custom wrapper.
+    if force_kill_pid && OSProcess.alive?(force_kill_pid) do
       Logger.warning("redis-server PID #{state.pid} still alive after SHUTDOWN, sending SIGKILL")
       # Kill the process group (negative PID) to get wrapper + child
-      warn_if_signal_unavailable(OSProcess.signal(-state.pid, :kill), state.pid)
+      warn_if_signal_unavailable(OSProcess.signal(-force_kill_pid, :kill), force_kill_pid)
       # Also try the individual PID in case process group kill didn't work
-      warn_if_signal_unavailable(OSProcess.signal(state.pid, :kill), state.pid)
+      warn_if_signal_unavailable(OSProcess.signal(force_kill_pid, :kill), force_kill_pid)
     end
-
-    # Extra safety: find and kill any redis-server on our port
-    kill_by_port(state.config.port)
 
     :ok
   end
@@ -330,12 +335,6 @@ defmodule RedisServerWrapper.Server do
 
   # Port-based: redis-server runs in the foreground, tied to the BEAM.
   defp start_managed(config, redis_server_bin, redis_cli_bin, timeout) do
-    # Check for stale process from a previous (possibly daemonized) run
-    stale_pidfile =
-      Path.join([System.tmp_dir!(), "redis-server-wrapper", "node-#{config.port}", "redis.pid"])
-
-    kill_stale_process(stale_pidfile)
-
     with :ok <- check_port_available(config.bind, config.port) do
       do_start_managed(config, redis_server_bin, redis_cli_bin, timeout)
     end
@@ -413,11 +412,6 @@ defmodule RedisServerWrapper.Server do
   # where terminate/2 never runs.
   defp start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout) do
     if forcola_available?() do
-      stale_pidfile =
-        Path.join([System.tmp_dir!(), "redis-server-wrapper", "node-#{config.port}", "redis.pid"])
-
-      kill_stale_process(stale_pidfile)
-
       with :ok <- check_port_available(config.bind, config.port) do
         do_start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout)
       end
@@ -595,36 +589,6 @@ defmodule RedisServerWrapper.Server do
     end
   end
 
-  defp kill_stale_process(pidfile_path) do
-    pidfile_path
-    |> read_pidfile()
-    |> maybe_kill_stale()
-  end
-
-  defp maybe_kill_stale(nil), do: :ok
-
-  defp maybe_kill_stale(stale_pid) do
-    # Only kill if the process is (a) alive and (b) actually orphaned
-    # (ppid=1). A prior daemonized run re-parents to init, so ppid=1 is
-    # the signal that this is truly stale. Any other parent means it is
-    # a managed Port child of some BEAM -- possibly our own -- and we
-    # must not kill it, or we'd murder a server that was just started on
-    # the same port by the same or a sibling process.
-    if OSProcess.alive?(stale_pid) and OSProcess.orphaned?(stale_pid) do
-      Logger.warning("Killing stale redis-server process #{stale_pid}")
-      warn_if_signal_unavailable(OSProcess.signal(stale_pid, :term), stale_pid)
-      Process.sleep(500)
-      force_kill_if_alive(stale_pid)
-    end
-  end
-
-  defp force_kill_if_alive(pid) do
-    if OSProcess.alive?(pid) do
-      Logger.warning("Stale PID #{pid} still alive, sending SIGKILL")
-      warn_if_signal_unavailable(OSProcess.signal(pid, :kill), pid)
-    end
-  end
-
   defp make_node_dir(port) do
     dir =
       Path.join([
@@ -665,23 +629,56 @@ defmodule RedisServerWrapper.Server do
     ArgumentError -> :ok
   end
 
-  # Kill any redis-server process listening on a specific port.
-  # This handles orphaned processes from wrapper scripts (redis-stack-server).
-  defp kill_by_port(port) when is_integer(port) do
-    case OSProcess.pids_on_port(port) do
-      {:ok, pids} ->
-        Enum.each(pids, fn pid ->
-          warn_if_signal_unavailable(OSProcess.signal(pid, :kill), pid)
-        end)
+  defp shutdown_if_owned(%{pid: nil}), do: :ok
 
-      {:error, {:executable_not_found, "lsof"}} ->
-        Logger.warning(
-          "lsof is unavailable; skipping best-effort process cleanup for Redis port #{port}"
-        )
+  defp shutdown_if_owned(state) do
+    if managed_port_owns_pid?(state.port_ref, state.pid) do
+      run_shutdown(state)
+    else
+      shutdown_if_listener_owned(state, OSProcess.pids_on_port(state.config.port))
     end
   end
 
-  defp kill_by_port(_), do: :ok
+  defp shutdown_if_listener_owned(state, {:ok, pids}) do
+    if state.pid in pids do
+      run_shutdown(state)
+    else
+      Logger.warning(
+        "Skipping Redis shutdown on port #{state.config.port}: " <>
+          "tracked PID #{state.pid} no longer owns the listener"
+      )
+    end
+  end
+
+  defp shutdown_if_listener_owned(state, {:error, {:executable_not_found, "lsof"}}) do
+    Logger.warning(
+      "lsof is unavailable; skipping ownership-sensitive Redis shutdown " <>
+        "on port #{state.config.port}"
+    )
+  end
+
+  defp run_shutdown(state) do
+    _result = Cli.run(state.cli, ["SHUTDOWN", "NOSAVE"])
+    :ok
+  end
+
+  defp managed_port_owns_pid?(port_ref, pid) when is_port(port_ref) and is_integer(pid) do
+    case :erlang.port_info(port_ref, :os_pid) do
+      {:os_pid, ^pid} -> true
+      _other -> false
+    end
+  end
+
+  defp managed_port_owns_pid?(_port_ref, _pid), do: false
+
+  defp pid_owns_port?(pid, port) when is_integer(pid) do
+    case OSProcess.pids_on_port(port) do
+      {:ok, pids} -> pid in pids
+      {:error, _reason} -> false
+    end
+  end
+
+  defp pid_owns_port?(_pid, _port), do: false
 
   defp warn_if_signal_unavailable(
          {:error, {:executable_not_found, "kill"}},

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -261,6 +261,23 @@ defmodule RedisServerWrapperTest do
 
       assert :ok = Server.stop(server)
     end
+
+    test "stopping stale Server state does not stop a replacement listener" do
+      port = 6416
+      {:ok, stale_server} = Server.start(port: port)
+      stale_pid = Server.info(stale_server).pid
+      assert :ok = RedisServerWrapper.OSProcess.signal(stale_pid, :kill)
+      assert wait_until(fn -> not Server.alive?(stale_server) end, 20, 100)
+
+      {:ok, replacement_server} = Server.start_link(port: port)
+
+      try do
+        assert :ok = Server.stop(stale_server)
+        assert Server.ping(replacement_server)
+      after
+        if Process.alive?(replacement_server), do: Server.stop(replacement_server)
+      end
+    end
   end
 
   describe "Server forcola mode" do
@@ -440,6 +457,119 @@ defmodule RedisServerWrapperTest do
       assert Manager.list() == []
     end
 
+    test "stale Manager state never shuts down a foreign listener", %{state_file: state_file} do
+      port = 6485
+      {:ok, existing_server} = Server.start_link(port: port, save: :disabled)
+
+      write_manager_state(
+        state_file,
+        %{
+          "stale-basic" =>
+            manager_instance("stale-basic", "basic", "2026-01-01T00:00:00Z")
+            |> Map.put("ports", [port])
+        }
+      )
+
+      try do
+        assert :ok = Manager.stop("stale-basic")
+        assert Server.ping(existing_server)
+        assert Manager.list() == []
+      after
+        if Process.alive?(existing_server), do: Server.stop(existing_server)
+      end
+    end
+
+    test "Manager retains state when a live recorded PID cannot be tied to a listener", %{
+      state_file: state_file
+    } do
+      live_pid = System.pid() |> String.to_integer()
+
+      write_manager_state(
+        state_file,
+        %{
+          "unverified-basic" =>
+            manager_instance("unverified-basic", "basic", "2026-01-01T00:00:00Z")
+            |> Map.put("pids", [live_pid])
+        }
+      )
+
+      assert {:error, {:process_ownership_not_verified, "unverified-basic", [^live_pid]}} =
+               Manager.stop("unverified-basic")
+
+      assert [%{name: "unverified-basic"}] = Manager.list()
+
+      assert {:error,
+              {:instances_not_stopped,
+               %{
+                 "unverified-basic" =>
+                   {:process_ownership_not_verified, "unverified-basic", [^live_pid]}
+               }}} = Manager.stop_all()
+
+      assert [%{name: "unverified-basic"}] = Manager.list()
+    end
+
+    test "Manager refuses teardown when listener ownership cannot be inspected", %{
+      state_file: state_file
+    } do
+      write_manager_state(
+        state_file,
+        %{
+          "uninspectable-basic" =>
+            manager_instance("uninspectable-basic", "basic", "2026-01-01T00:00:00Z")
+            |> Map.put("ports", [6486])
+        }
+      )
+
+      original_path = System.get_env("PATH")
+      empty_path = Path.join(Path.dirname(state_file), "empty-path")
+      File.mkdir_p!(empty_path)
+      System.put_env("PATH", empty_path)
+
+      try do
+        assert {:error,
+                {:process_ownership_not_verified, "uninspectable-basic",
+                 {:executable_not_found, "lsof"}}} = Manager.stop("uninspectable-basic")
+      after
+        System.put_env("PATH", original_path)
+      end
+
+      assert [%{name: "uninspectable-basic"}] = Manager.list()
+    end
+
+    test "Manager signals only the recorded listener when graceful authentication fails", %{
+      state_file: state_file
+    } do
+      port = 6487
+
+      {:ok, server} =
+        Server.start_link(
+          port: port,
+          password: "actual-password",
+          managed: false,
+          save: :disabled
+        )
+
+      server_info = Server.info(server)
+
+      write_manager_state(
+        state_file,
+        %{
+          "owned-basic" =>
+            manager_instance("owned-basic", "basic", "2026-01-01T00:00:00Z")
+            |> Map.put("ports", [port])
+            |> Map.put("pids", [server_info.pid])
+            |> Map.put("password", "wrong-password")
+        }
+      )
+
+      try do
+        assert :ok = Manager.stop("owned-basic")
+        assert wait_until(fn -> not Server.alive?(server) end, 10, 200)
+      after
+        if Process.alive?(server), do: Server.stop(server)
+      end
+    end
+
     test "topology launchers preserve startup errors" do
       invalid_modules = [{"/missing/module.so", [:not_a_string]}]
 
@@ -526,6 +656,24 @@ defmodule RedisServerWrapperTest do
   end
 
   describe "Cluster" do
+    test "occupied node ports fail closed without stopping the existing server or deleting data" do
+      port = 7460
+      {:ok, existing_server} = Server.start_link(port: port, save: :disabled)
+      existing_info = Server.info(existing_server)
+      unrelated_dump = Path.join(existing_info.node_dir, "dump.rdb")
+      File.write!(unrelated_dump, "belongs to the existing server")
+
+      try do
+        assert {:error, {:node_start_failed, ^port, {:port_in_use, ^port, _reason}}} =
+                 Cluster.start(masters: 1, base_port: port)
+
+        assert Server.ping(existing_server)
+        assert File.read!(unrelated_dump) == "belongs to the existing server"
+      after
+        if Process.alive?(existing_server), do: Server.stop(existing_server)
+      end
+    end
+
     @tag timeout: 30_000
     test "start 3-master cluster, verify health, stop" do
       {:ok, cluster} = RedisServerWrapper.start_cluster(masters: 3, base_port: 7100)
@@ -563,6 +711,46 @@ defmodule RedisServerWrapperTest do
   end
 
   describe "Sentinel" do
+    test "occupied master port fails closed without stopping the existing server" do
+      master_port = 7470
+      {:ok, existing_server} = Server.start_link(port: master_port, save: :disabled)
+
+      try do
+        assert {:error, {:port_in_use, ^master_port, _reason}} =
+                 Sentinel.start(
+                   master_port: master_port,
+                   replicas: 0,
+                   sentinels: 1,
+                   sentinel_base_port: 27_470,
+                   quorum: 1
+                 )
+
+        assert Server.ping(existing_server)
+      after
+        if Process.alive?(existing_server), do: Server.stop(existing_server)
+      end
+    end
+
+    @tag timeout: 30_000
+    test "sentinel topology supports zero replicas without creating phantom ports" do
+      {:ok, sentinel} =
+        Sentinel.start_link(
+          master_port: 6510,
+          replicas: 0,
+          sentinels: 1,
+          sentinel_base_port: 26_510,
+          quorum: 1
+        )
+
+      try do
+        assert wait_until(fn -> Sentinel.healthy?(sentinel) end)
+        assert Sentinel.info(sentinel).replicas == 0
+        assert Sentinel.sentinel_addrs(sentinel) == ["127.0.0.1:26510"]
+      after
+        if Process.alive?(sentinel), do: Sentinel.stop(sentinel)
+      end
+    end
+
     @tag timeout: 30_000
     test "start sentinel topology, verify health, stop" do
       {:ok, sentinel} =

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -1,9 +1,7 @@
 defmodule RedisServerWrapperUnitTest do
   use ExUnit.Case, async: false
 
-  import ExUnit.CaptureLog
-
-  alias RedisServerWrapper.{Cli, Cluster, OSProcess, Server}
+  alias RedisServerWrapper.{Cli, Cluster, OSProcess, Sentinel, Server}
 
   setup do
     fixture_dir =
@@ -216,7 +214,7 @@ defmodule RedisServerWrapperUnitTest do
     assert {:ok, [123, 456]} = OSProcess.pids_on_port(6490)
   end
 
-  test "missing kill and lsof do not crash teardown or cluster pre-cleanup", %{
+  test "missing kill and lsof do not crash process helpers or normal teardown", %{
     cli_bin: cli_bin
   } do
     redis_server_bin = System.find_executable("redis-server")
@@ -237,28 +235,72 @@ defmodule RedisServerWrapperUnitTest do
     assert is_boolean(OSProcess.alive?(String.to_integer(System.pid())))
     assert is_boolean(OSProcess.orphaned?(String.to_integer(System.pid())))
 
-    log =
-      capture_log(fn ->
-        assert {:ok, server} =
-                 Server.start_link(
-                   port: 6490,
-                   redis_server_bin: redis_server_bin,
-                   redis_cli_bin: redis_cli_bin
-                 )
+    assert {:ok, server} =
+             Server.start_link(
+               port: 6490,
+               redis_server_bin: redis_server_bin,
+               redis_cli_bin: redis_cli_bin
+             )
 
-        assert :ok = Server.stop(server)
+    assert :ok = Server.stop(server)
 
-        assert {:error, {:node_start_failed, 7490, _reason}} =
-                 Cluster.start(
-                   masters: 1,
-                   base_port: 7490,
-                   timeout: 20,
-                   redis_server_bin: false_bin,
-                   redis_cli_bin: cli_bin
-                 )
-      end)
+    assert {:error, {:node_start_failed, 7490, _reason}} =
+             Cluster.start(
+               masters: 1,
+               base_port: 7490,
+               timeout: 20,
+               redis_server_bin: false_bin,
+               redis_cli_bin: cli_bin
+             )
+  end
 
-    assert log =~ "lsof is unavailable"
+  test "cluster validates counts, ports, and timeouts before startup" do
+    assert {:error, {:invalid_option, :masters, 0}} = Cluster.start(masters: 0)
+
+    assert {:error, {:invalid_option, :replicas_per_master, -1}} =
+             Cluster.start(replicas_per_master: -1)
+
+    assert {:error, {:invalid_option, :timeout, 0}} = Cluster.start(timeout: 0)
+    assert {:error, {:invalid_option, :base_port, 0}} = Cluster.start(base_port: 0)
+
+    assert {:error, {:invalid_port_range, :cluster_nodes, 65_535, 65_536}} =
+             Cluster.start(masters: 2, base_port: 65_535)
+
+    assert {:error, {:invalid_port_range, :cluster_bus, 65_536, 65_536}} =
+             Cluster.start(masters: 1, base_port: 55_536)
+
+    assert {:error,
+            {:overlapping_port_ranges, :cluster_nodes, 1, 10_001, :cluster_bus, 10_001, 20_001}} =
+             Cluster.start(masters: 10_001, base_port: 1)
+  end
+
+  test "sentinel validates counts, quorum, ports, and timeouts before startup" do
+    assert {:error, {:invalid_option, :replicas, -1}} = Sentinel.start(replicas: -1)
+    assert {:error, {:invalid_option, :sentinels, 0}} = Sentinel.start(sentinels: 0)
+    assert {:error, {:invalid_quorum, 4, 3}} = Sentinel.start(quorum: 4)
+    assert {:error, {:invalid_option, :timeout, 0}} = Sentinel.start(timeout: 0)
+    assert {:error, {:invalid_option, :master_port, "bad"}} = Sentinel.start(master_port: "bad")
+
+    assert {:error, {:invalid_option, :sentinel_base_port, 0}} =
+             Sentinel.start(sentinel_base_port: 0)
+
+    assert {:error, {:invalid_option, :replicas_base_port, "bad"}} =
+             Sentinel.start(replicas: 1, replica_base_port: "bad")
+
+    assert {:error, {:invalid_port_range, :replicas, 65_535, 65_536}} =
+             Sentinel.start(replicas: 2, replica_base_port: 65_535)
+
+    assert {:error, {:invalid_port_range, :sentinels, 65_535, 65_536}} =
+             Sentinel.start(sentinels: 2, sentinel_base_port: 65_535, quorum: 1)
+
+    assert {:error, {:overlapping_ports, [6390, 6391, 6391]}} =
+             Sentinel.start(
+               replicas: 1,
+               sentinels: 1,
+               replica_base_port: 6391,
+               sentinel_base_port: 6391,
+               quorum: 1
+             )
   end
 
   defp write_executable(dir, name, contents) do


### PR DESCRIPTION
## Summary

- remove broad cluster-directory cleanup and preserve pre-existing Redis data
- fail closed when requested ports are already occupied instead of shutting down or signaling an unrelated Redis process
- verify tracked process ownership before Manager and Server shutdown, preserving state when ownership cannot be proven
- validate cluster and Sentinel topology counts, quorum, timeouts, data ports, cluster-bus ports, and overlap before startup
- support a zero-replica Sentinel topology and derive a valid default quorum for small Sentinel counts
- document the occupied-port and process-ownership behavior

## Why

Cluster and Sentinel startup previously tried to clear requested ports and cluster state aggressively. That could stop an unrelated Redis instance or remove data outside the wrapper's ownership. Invalid topology values could also fail late, after partial startup.

This changes startup and teardown to be ownership-aware and fail before mutation when the requested topology cannot be safely created.

## Verification

- `mix test --cover` — 68 tests, 91.67% coverage
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`

Closes #52
Closes #53
Closes #58