### PR TITLE
fix: harden manager credential handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,21 @@ RedisServerWrapper.Manager.start_basic(name: "dev-redis", port: 6400)
 RedisServerWrapper.Manager.list()
 #=> [%{name: "dev-redis", type: :basic, ...}]
 
+RedisServerWrapper.Manager.credentials("dev-redis")
+#=> {:ok, %{password: "password", url: "redis://:password@127.0.0.1:6400"}}
+
 RedisServerWrapper.Manager.stop("dev-redis")
 ```
+
+Manager-generated passwords come from the operating system's cryptographic
+random source. Console output redacts credentials; use `Manager.credentials/1`
+when plaintext access is intentional. The Manager state directory and
+credential-bearing Redis configuration directories are created with mode
+`0700`, while state and configuration files use `0600`. State updates are
+atomic and serialized across connected BEAM nodes. Independent, unconnected
+BEAM instances must not write to the same Manager state file concurrently.
+Invalid state is moved aside as an `instances.json.corrupt-*` recovery copy
+instead of being overwritten.
 
 ### Managed Process Lifecycle
 

--- a/lib/redis_server_wrapper/cli.ex
+++ b/lib/redis_server_wrapper/cli.ex
@@ -34,7 +34,7 @@ defmodule RedisServerWrapper.Cli do
   def run(%__MODULE__{} = cli, args) when is_list(args) do
     full_args = base_args(cli) ++ args
 
-    case System.cmd(cli.bin, full_args, stderr_to_stdout: true) do
+    case run_command(cli, full_args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, _code} -> {:error, String.trim(output)}
     end
@@ -138,10 +138,9 @@ defmodule RedisServerWrapper.Cli do
     args =
       ["--cluster", "create"] ++
         node_addrs ++
-        ["--cluster-replicas", to_string(replicas_per_master), "--cluster-yes"] ++
-        auth_args(cli)
+        ["--cluster-replicas", to_string(replicas_per_master), "--cluster-yes"]
 
-    case System.cmd(cli.bin, args, stderr_to_stdout: true) do
+    case run_command(cli, args) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, _code} -> {:error, String.trim(output)}
     end
@@ -172,12 +171,20 @@ defmodule RedisServerWrapper.Cli do
   # Build base connection arguments for redis-cli
   defp base_args(%__MODULE__{} = cli) do
     ["-h", cli.host, "-p", to_string(cli.port)]
-    |> maybe_append(cli.password, fn pw -> ["-a", pw, "--no-auth-warning"] end)
     |> maybe_append(cli.tls, fn _ -> ["--tls"] end)
   end
 
-  defp auth_args(%__MODULE__{password: nil}), do: []
-  defp auth_args(%__MODULE__{password: pw}), do: ["-a", pw, "--no-auth-warning"]
+  defp run_command(cli, args) do
+    System.cmd(
+      cli.bin,
+      args,
+      stderr_to_stdout: true,
+      env: auth_env(cli)
+    )
+  end
+
+  defp auth_env(%__MODULE__{password: nil}), do: []
+  defp auth_env(%__MODULE__{password: password}), do: [{"REDISCLI_AUTH", password}]
 
   defp maybe_append(args, nil, _fun), do: args
   defp maybe_append(args, false, _fun), do: args

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -16,10 +16,13 @@ defmodule RedisServerWrapper.Manager do
       Manager.stop("redis-basic-1")
       Manager.cleanup()
 
-  State is stored at `~/.config/redis-server-wrapper/instances.json`.
+  State is stored at `~/.config/redis-server-wrapper/instances.json`. Mutating
+  operations are serialized within a connected BEAM cluster and use atomic
+  file replacement. Independent, unconnected BEAM instances must not write to
+  the same state file concurrently.
   """
 
-  alias RedisServerWrapper.{Cli, Cluster, OSProcess, Sentinel, Server}
+  alias RedisServerWrapper.{Cli, Cluster, OSProcess, SecureFile, Sentinel, Server}
 
   require Logger
 
@@ -58,6 +61,10 @@ defmodule RedisServerWrapper.Manager do
   """
   @spec start_basic(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_basic(opts \\ []) do
+    with_state_lock(fn -> do_start_basic(opts) end)
+  end
+
+  defp do_start_basic(opts) do
     state = load_state()
     name = Keyword.get(opts, :name) || generate_name(state, :basic)
     password = resolve_password(opts)
@@ -131,6 +138,10 @@ defmodule RedisServerWrapper.Manager do
   """
   @spec start_cluster(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_cluster(opts \\ []) do
+    with_state_lock(fn -> do_start_cluster(opts) end)
+  end
+
+  defp do_start_cluster(opts) do
     state = load_state()
     name = Keyword.get(opts, :name) || generate_name(state, :cluster)
     password = resolve_password(opts)
@@ -209,6 +220,10 @@ defmodule RedisServerWrapper.Manager do
   """
   @spec start_sentinel(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_sentinel(opts \\ []) do
+    with_state_lock(fn -> do_start_sentinel(opts) end)
+  end
+
+  defp do_start_sentinel(opts) do
     state = load_state()
     name = Keyword.get(opts, :name) || generate_name(state, :sentinel)
     password = resolve_password(opts)
@@ -339,10 +354,38 @@ defmodule RedisServerWrapper.Manager do
   end
 
   @doc """
+  Returns the credentials for a named instance without printing them.
+
+  Manager console output is redacted by default. Use this function when a
+  caller explicitly needs the plaintext password or connection URL.
+  """
+  @spec credentials(String.t()) ::
+          {:ok, %{password: String.t() | nil, url: String.t()}} | {:error, :not_found}
+  def credentials(name) do
+    state = load_state()
+
+    case Map.get(state.instances, name) do
+      nil ->
+        {:error, :not_found}
+
+      instance ->
+        {:ok,
+         %{
+           password: instance.password,
+           url: build_url(instance.bind, List.first(instance.ports), instance.password)
+         }}
+    end
+  end
+
+  @doc """
   Stops a named instance by sending SHUTDOWN to all its processes.
   """
   @spec stop(String.t()) :: :ok | {:error, term()}
   def stop(name) do
+    with_state_lock(fn -> do_stop(name) end)
+  end
+
+  defp do_stop(name) do
     state = load_state()
 
     case Map.get(state.instances, name) do
@@ -367,6 +410,10 @@ defmodule RedisServerWrapper.Manager do
   """
   @spec stop_all() :: :ok | {:error, {:instances_not_stopped, map()}}
   def stop_all do
+    with_state_lock(&do_stop_all/0)
+  end
+
+  defp do_stop_all do
     state = load_state()
 
     {remaining, failures} =
@@ -399,6 +446,10 @@ defmodule RedisServerWrapper.Manager do
   """
   @spec cleanup() :: {non_neg_integer(), non_neg_integer()}
   def cleanup do
+    with_state_lock(&do_cleanup/0)
+  end
+
+  defp do_cleanup do
     state = load_state()
 
     {running, dead} =
@@ -422,28 +473,95 @@ defmodule RedisServerWrapper.Manager do
 
   defp load_state do
     state_file = state_file()
-    File.mkdir_p!(Path.dirname(state_file))
+    ensure_state_directory!(state_file)
 
-    case File.read(state_file) do
-      {:ok, content} when byte_size(content) > 0 ->
-        data = JSON.decode!(content)
-        deserialize_state(data)
+    case SecureFile.harden_private_file(state_file) do
+      :ok ->
+        read_state_file(state_file)
 
-      _ ->
+      :missing ->
         empty_state()
+
+      {:error, reason} ->
+        recover_corrupt_state(state_file, reason)
     end
   end
 
   defp save_state(state) do
     state_file = state_file()
-    File.mkdir_p!(Path.dirname(state_file))
+    ensure_state_directory!(state_file)
     json = encode_json(serialize_state(state))
-    File.write!(state_file, json)
+    SecureFile.atomic_write_private!(state_file, json)
     state
+  end
+
+  defp read_state_file(state_file) do
+    case File.read(state_file) do
+      {:ok, ""} ->
+        empty_state()
+
+      {:ok, content} ->
+        decode_state(state_file, content)
+
+      {:error, :enoent} ->
+        empty_state()
+
+      {:error, reason} ->
+        recover_corrupt_state(state_file, reason)
+    end
+  end
+
+  defp decode_state(state_file, content) do
+    case JSON.decode(content) do
+      {:ok, data} ->
+        deserialize_state(data)
+
+      {:error, reason} ->
+        recover_corrupt_state(state_file, reason)
+    end
+  rescue
+    error -> recover_corrupt_state(state_file, Exception.message(error))
+  end
+
+  defp recover_corrupt_state(state_file, reason) do
+    backup = "#{state_file}.corrupt-#{System.unique_integer([:positive, :monotonic])}"
+
+    case File.rename(state_file, backup) do
+      :ok ->
+        Logger.error(
+          "Manager state was invalid and has been preserved at #{backup}: #{inspect(reason)}"
+        )
+
+      {:error, :enoent} ->
+        Logger.warning("Manager state disappeared while recovering invalid data")
+
+      {:error, rename_reason} ->
+        raise File.Error,
+          reason: rename_reason,
+          action: "preserve invalid Manager state",
+          path: state_file
+    end
+
+    empty_state()
+  end
+
+  defp ensure_state_directory!(state_file) do
+    directory = Path.dirname(state_file)
+    directory_existed? = File.dir?(directory)
+    File.mkdir_p!(directory)
+
+    if not directory_existed? or Path.expand(state_file) == Path.expand(@default_state_file) do
+      File.chmod!(directory, 0o700)
+    end
   end
 
   defp state_file do
     Application.get_env(:redis_server_wrapper, :manager_state_file, @default_state_file)
+  end
+
+  defp with_state_lock(fun) do
+    resource = {__MODULE__, Path.expand(state_file())}
+    :global.trans({resource, self()}, fun)
   end
 
   defp empty_state, do: %{instances: %{}, counters: %{}}
@@ -457,20 +575,26 @@ defmodule RedisServerWrapper.Manager do
     %{"instances" => instances, "counters" => state.counters}
   end
 
-  defp deserialize_state(data) do
+  defp deserialize_state(%{"instances" => instances} = data) when is_map(instances) do
     instances =
-      (data["instances"] || %{})
-      |> Map.new(fn {name, inst} -> {name, deserialize_instance(name, inst)} end)
+      Map.new(instances, fn {name, inst} -> {name, deserialize_instance(name, inst)} end)
 
     counters = data["counters"] || %{}
 
-    %{instances: instances, counters: counters}
+    if is_map(counters) do
+      %{instances: instances, counters: counters}
+    else
+      raise ArgumentError, "Manager state counters must be an object"
+    end
   end
 
-  defp deserialize_instance(name, inst) do
+  defp deserialize_state(%{} = data) when map_size(data) == 0, do: empty_state()
+  defp deserialize_state(_data), do: raise(ArgumentError, "Manager state must be an object")
+
+  defp deserialize_instance(name, inst) when is_map(inst) do
     %{
       name: inst["name"] || name,
-      type: String.to_existing_atom(inst["type"] || "basic"),
+      type: deserialize_type(inst["type"] || "basic"),
       created_at: inst["created_at"],
       bind: inst["bind"] || "127.0.0.1",
       ports: inst["ports"] || [],
@@ -481,15 +605,29 @@ defmodule RedisServerWrapper.Manager do
     }
   end
 
+  defp deserialize_instance(_name, _inst),
+    do: raise(ArgumentError, "Manager instance state must be an object")
+
+  defp deserialize_type("basic"), do: :basic
+  defp deserialize_type("cluster"), do: :cluster
+  defp deserialize_type("sentinel"), do: :sentinel
+  defp deserialize_type(type), do: raise(ArgumentError, "unknown Manager instance type: #{type}")
+
   defp atomize_keys(map) when is_map(map) do
     Map.new(map, fn
-      {k, v} when is_binary(k) -> {String.to_atom(k), atomize_keys(v)}
+      {k, v} when is_binary(k) -> {existing_atom_or_string(k), atomize_keys(v)}
       {k, v} -> {k, atomize_keys(v)}
     end)
   end
 
   defp atomize_keys(list) when is_list(list), do: Enum.map(list, &atomize_keys/1)
   defp atomize_keys(value), do: value
+
+  defp existing_atom_or_string(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
 
   defp encode_json(data) do
     JSON.encode!(data)
@@ -537,11 +675,10 @@ defmodule RedisServerWrapper.Manager do
     end
   end
 
-  @password_chars ~c"bcdfghjkmnpqrstvwxyz23456789BCDFGHJKMNPQRSTVWXYZ"
   defp generate_password(length \\ 16) do
-    for _ <- 1..length, into: "" do
-      <<Enum.random(@password_chars)>>
-    end
+    :crypto.strong_rand_bytes(length)
+    |> Base.url_encode64(padding: false)
+    |> binary_part(0, length)
   end
 
   # -------------------------------------------------------------------
@@ -670,8 +807,20 @@ defmodule RedisServerWrapper.Manager do
   # URL building
   # -------------------------------------------------------------------
 
-  defp build_url(host, port, nil), do: "redis://#{host}:#{port}"
-  defp build_url(host, port, password), do: "redis://:#{password}@#{host}:#{port}"
+  defp build_url(host, port, nil), do: "redis://#{url_host(host)}:#{port}"
+
+  defp build_url(host, port, password) do
+    encoded_password = URI.encode(password, &URI.char_unreserved?/1)
+    "redis://:#{encoded_password}@#{url_host(host)}:#{port}"
+  end
+
+  defp url_host(host) do
+    if String.contains?(host, ":") and not String.starts_with?(host, "[") do
+      "[#{host}]"
+    else
+      host
+    end
+  end
 
   # -------------------------------------------------------------------
   # Display helpers
@@ -680,12 +829,12 @@ defmodule RedisServerWrapper.Manager do
   defp print_instance(instance) do
     IO.puts("")
     IO.puts("  #{instance.name} (#{instance.type})")
-    IO.puts("  URL: #{instance.url}")
+    IO.puts("  URL: #{redact_url(instance.url)}")
     IO.puts("  Ports: #{Enum.join(instance.ports, ", ")}")
     IO.puts("  PIDs: #{Enum.join(instance.pids, ", ")}")
 
     if instance.password do
-      IO.puts("  Password: #{instance.password}")
+      IO.puts("  Password: [REDACTED]")
     end
 
     IO.puts("")
@@ -705,13 +854,13 @@ defmodule RedisServerWrapper.Manager do
     IO.puts("  #{instance.name}")
     IO.puts("  Type:     #{instance.type}")
     IO.puts("  Status:   #{instance.status}")
-    IO.puts("  URL:      #{instance.url}")
+    IO.puts("  URL:      #{redact_url(instance.url)}")
     IO.puts("  Ports:    #{Enum.join(instance.ports, ", ")}")
     IO.puts("  PIDs:     #{Enum.join(instance.pids, ", ")}")
     IO.puts("  Created:  #{instance.created_at}")
 
     if instance.password do
-      IO.puts("  Password: #{instance.password}")
+      IO.puts("  Password: [REDACTED]")
     end
 
     if map_size(instance.metadata) > 0 do
@@ -719,6 +868,10 @@ defmodule RedisServerWrapper.Manager do
     end
 
     IO.puts("")
+  end
+
+  defp redact_url(url) do
+    String.replace(url, ~r/\A(redis(?:s)?:\/\/)[^@]+@/, "\\1[REDACTED]@")
   end
 
   # -------------------------------------------------------------------

--- a/lib/redis_server_wrapper/secure_file.ex
+++ b/lib/redis_server_wrapper/secure_file.ex
@@ -1,0 +1,78 @@
+defmodule RedisServerWrapper.SecureFile do
+  @moduledoc false
+
+  @directory_mode 0o700
+  @file_mode 0o600
+
+  @spec make_private_directory!(Path.t()) :: :ok
+  def make_private_directory!(path) do
+    File.mkdir_p!(path)
+    File.chmod!(path, @directory_mode)
+  end
+
+  @spec write_private!(Path.t(), iodata()) :: :ok
+  def write_private!(path, contents) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :regular}} ->
+        File.chmod!(path, @file_mode)
+        write_existing!(path, contents)
+
+      {:ok, %File.Stat{type: type}} ->
+        raise ArgumentError,
+              "refusing to write private data to non-regular #{type}: #{path}"
+
+      {:error, :enoent} ->
+        create_private!(path, contents)
+
+      {:error, reason} ->
+        raise File.Error, reason: reason, action: "inspect private file", path: path
+    end
+  end
+
+  @spec atomic_write_private!(Path.t(), iodata()) :: :ok
+  def atomic_write_private!(path, contents) do
+    suffix = System.unique_integer([:positive, :monotonic])
+    temp_path = Path.join(Path.dirname(path), ".#{Path.basename(path)}.tmp-#{suffix}")
+
+    try do
+      create_private!(temp_path, contents)
+      File.rename!(temp_path, path)
+      File.chmod!(path, @file_mode)
+    after
+      File.rm(temp_path)
+    end
+  end
+
+  @spec harden_private_file(Path.t()) ::
+          :ok | :missing | {:error, {:not_a_regular_file, atom()}} | {:error, term()}
+  def harden_private_file(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :regular}} ->
+        File.chmod(path, @file_mode)
+
+      {:ok, %File.Stat{type: type}} ->
+        {:error, {:not_a_regular_file, type}}
+
+      {:error, :enoent} ->
+        :missing
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp create_private!(path, contents) do
+    File.open!(path, [:write, :exclusive, :binary], fn io ->
+      File.chmod!(path, @file_mode)
+      IO.binwrite(io, contents)
+      :ok = :file.sync(io)
+    end)
+  end
+
+  defp write_existing!(path, contents) do
+    File.open!(path, [:write, :binary], fn io ->
+      IO.binwrite(io, contents)
+      :ok = :file.sync(io)
+    end)
+  end
+end

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -41,7 +41,7 @@ defmodule RedisServerWrapper.Sentinel do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, OSProcess, Server}
+  alias RedisServerWrapper.{Cli, OSProcess, SecureFile, Server}
 
   require Logger
 
@@ -378,7 +378,7 @@ defmodule RedisServerWrapper.Sentinel do
         "sentinel-#{System.system_time(:nanosecond)}"
       ])
 
-    File.mkdir_p!(sentinel_dir)
+    SecureFile.make_private_directory!(sentinel_dir)
 
     results =
       Enum.reduce_while(0..(count - 1), {:ok, []}, fn i, {:ok, acc} ->
@@ -402,11 +402,11 @@ defmodule RedisServerWrapper.Sentinel do
 
   defp start_single_sentinel(opts, sentinel_dir, port) do
     node_dir = Path.join(sentinel_dir, "sentinel-#{port}")
-    File.mkdir_p!(node_dir)
+    SecureFile.make_private_directory!(node_dir)
 
     conf_content = generate_sentinel_conf(opts, node_dir, port)
     conf_path = Path.join(node_dir, "sentinel.conf")
-    File.write!(conf_path, conf_content)
+    SecureFile.write_private!(conf_path, conf_content)
 
     start_sentinel_process(
       opts.redis_server_bin,
@@ -468,7 +468,19 @@ defmodule RedisServerWrapper.Sentinel do
          port,
          timeout
        ) do
-    case System.cmd(redis_server_bin, [conf_path, "--sentinel"], stderr_to_stdout: true) do
+    # Sentinel rewrites its configuration as topology state changes. Launch it
+    # with a private umask so every replacement keeps credential-bearing config
+    # private, not only the initial file written above.
+    command_args = [
+      "-c",
+      ~S(umask 077; exec "$@"),
+      "redis-server-wrapper",
+      redis_server_bin,
+      conf_path,
+      "--sentinel"
+    ]
+
+    case System.cmd("/bin/sh", command_args, stderr_to_stdout: true) do
       {_output, 0} ->
         # Wait for sentinel to be ready
         cli = Cli.new(bin: redis_cli_bin, host: bind, port: port)

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -38,7 +38,7 @@ defmodule RedisServerWrapper.Server do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Config, OSProcess}
+  alias RedisServerWrapper.{Cli, Config, OSProcess, SecureFile}
 
   require Logger
 
@@ -352,7 +352,7 @@ defmodule RedisServerWrapper.Server do
     }
 
     conf_path = Path.join(node_dir, "redis.conf")
-    File.write!(conf_path, Config.to_config_string(config))
+    SecureFile.write_private!(conf_path, Config.to_config_string(config))
 
     server_bin_path = System.find_executable(redis_server_bin)
 
@@ -432,7 +432,7 @@ defmodule RedisServerWrapper.Server do
     }
 
     conf_path = Path.join(node_dir, "redis.conf")
-    File.write!(conf_path, Config.to_config_string(config))
+    SecureFile.write_private!(conf_path, Config.to_config_string(config))
 
     server_bin_path = System.find_executable(redis_server_bin)
 
@@ -512,7 +512,7 @@ defmodule RedisServerWrapper.Server do
     }
 
     conf_path = Path.join(node_dir, "redis.conf")
-    File.write!(conf_path, Config.to_config_string(config))
+    SecureFile.write_private!(conf_path, Config.to_config_string(config))
 
     server_bin_path = System.find_executable(redis_server_bin) || redis_server_bin
 
@@ -598,7 +598,7 @@ defmodule RedisServerWrapper.Server do
       ])
 
     File.rm_rf!(dir)
-    File.mkdir_p!(dir)
+    SecureFile.make_private_directory!(dir)
     dir
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule RedisServerWrapper.MixProject do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:crypto, :logger],
       mod: {RedisServerWrapper.Application, []}
     ]
   end

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -170,6 +170,10 @@ defmodule RedisServerWrapperTest do
       assert {:ok, "OK"} = Server.run(server, ["SET", "k", "v"])
       assert {:ok, "v"} = Server.run(server, ["GET", "k"])
 
+      node_dir = Server.info(server).node_dir
+      assert file_mode(node_dir) == 0o700
+      assert file_mode(Path.join(node_dir, "redis.conf")) == 0o600
+
       Server.stop(server)
       Process.sleep(500)
     end
@@ -378,7 +382,7 @@ defmodule RedisServerWrapperTest do
       Application.put_env(:redis_server_wrapper, :manager_state_file, state_file)
 
       on_exit(fn ->
-        Enum.each([6430, 6470, 6471, 7430, 7431, 7432, 26_470], fn port ->
+        Enum.each([6430, 6470, 6471, 6488, 6489, 7430, 7431, 7432, 26_470], fn port ->
           Cli.shutdown(Cli.new(port: port))
         end)
 
@@ -415,6 +419,120 @@ defmodule RedisServerWrapperTest do
 
       assert :ok = Manager.stop(instance.name)
       assert wait_until(fn -> not Cli.ping(cli) end, 5, 200)
+    end
+
+    test "credentials stay out of default output and state is private", %{state_file: state_file} do
+      password = "a:b@/?#%"
+      parent = self()
+
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          send(
+            parent,
+            {:started,
+             Manager.start_basic(
+               name: "redacted-basic",
+               port: 6488,
+               password: password
+             )}
+          )
+        end)
+
+      assert_receive {:started, {:ok, instance}}
+
+      try do
+        refute output =~ password
+        assert output =~ "[REDACTED]"
+        assert file_mode(Path.dirname(state_file)) == 0o700
+        assert file_mode(state_file) == 0o600
+
+        assert {:ok, credentials} = Manager.credentials(instance.name)
+        assert credentials.password == password
+
+        assert credentials.url ==
+                 "redis://:a%3Ab%40%2F%3F%23%25@127.0.0.1:6488"
+
+        info_output =
+          ExUnit.CaptureIO.capture_io(fn ->
+            assert {:ok, %{name: "redacted-basic"}} = Manager.info(instance.name)
+          end)
+
+        refute info_output =~ password
+        assert info_output =~ "[REDACTED]"
+      after
+        Manager.stop(instance.name)
+      end
+    end
+
+    test "credentials encode IPv6 hosts and URL-significant passwords", %{state_file: state_file} do
+      password = "space and:@/%?#"
+
+      write_manager_state(state_file, %{
+        "ipv6-basic" =>
+          manager_instance("ipv6-basic", "basic", "2026-01-01T00:00:00Z")
+          |> Map.put("bind", "::1")
+          |> Map.put("ports", [6379])
+          |> Map.put("password", password)
+      })
+
+      assert {:ok, %{password: ^password, url: url}} = Manager.credentials("ipv6-basic")
+      assert url == "redis://:space%20and%3A%40%2F%25%3F%23@[::1]:6379"
+    end
+
+    test "invalid state is preserved and does not crash Manager", %{state_file: state_file} do
+      File.mkdir_p!(Path.dirname(state_file))
+      File.write!(state_file, ~s({"instances":))
+      File.chmod!(state_file, 0o644)
+
+      assert Manager.list() == []
+      refute File.exists?(state_file)
+
+      assert [backup] = Path.wildcard("#{state_file}.corrupt-*")
+      assert File.read!(backup) == ~s({"instances":)
+      assert file_mode(backup) == 0o600
+    end
+
+    test "unknown metadata keys never create atoms", %{state_file: state_file} do
+      unknown_key = "manager_unknown_#{System.unique_integer([:positive])}"
+
+      assert_raise ArgumentError, fn -> String.to_existing_atom(unknown_key) end
+
+      write_manager_state(state_file, %{
+        "metadata-basic" =>
+          manager_instance("metadata-basic", "basic", "2026-01-01T00:00:00Z")
+          |> Map.put("metadata", %{unknown_key => "retained"})
+      })
+
+      assert {:ok, info} = Manager.info("metadata-basic")
+      assert info.metadata[unknown_key] == "retained"
+      assert_raise ArgumentError, fn -> String.to_existing_atom(unknown_key) end
+    end
+
+    @tag timeout: 30_000
+    test "concurrent Manager mutations retain every instance and valid JSON", %{
+      state_file: state_file
+    } do
+      tasks =
+        [
+          {"concurrent-a", 6488},
+          {"concurrent-b", 6489}
+        ]
+        |> Enum.map(fn {name, port} ->
+          Task.async(fn -> Manager.start_basic(name: name, port: port, password: nil) end)
+        end)
+
+      assert Enum.all?(Task.await_many(tasks, 20_000), &match?({:ok, _instance}, &1))
+
+      assert Manager.list()
+             |> Enum.map(& &1.name)
+             |> Enum.sort() == ["concurrent-a", "concurrent-b"]
+
+      assert {:ok, %{"instances" => instances}} =
+               state_file |> File.read!() |> JSON.decode()
+
+      assert Map.keys(instances) |> Enum.sort() == ["concurrent-a", "concurrent-b"]
+      assert file_mode(state_file) == 0o600
+      assert :ok = Manager.stop_all()
     end
 
     test "persisted state supports listing, filtering, details, and missing names", %{
@@ -746,6 +864,12 @@ defmodule RedisServerWrapperTest do
         assert wait_until(fn -> Sentinel.healthy?(sentinel) end)
         assert Sentinel.info(sentinel).replicas == 0
         assert Sentinel.sentinel_addrs(sentinel) == ["127.0.0.1:26510"]
+
+        sentinel_dir = :sys.get_state(sentinel).sentinel_dir
+        sentinel_conf = Path.join([sentinel_dir, "sentinel-26510", "sentinel.conf"])
+        assert file_mode(sentinel_dir) == 0o700
+        assert file_mode(Path.dirname(sentinel_conf)) == 0o700
+        assert file_mode(sentinel_conf) == 0o600
       after
         if Process.alive?(sentinel), do: Sentinel.stop(sentinel)
       end
@@ -789,6 +913,8 @@ defmodule RedisServerWrapperTest do
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, JSON.encode!(state))
   end
+
+  defp file_mode(path), do: Bitwise.band(File.stat!(path).mode, 0o777)
 
   defp manager_instance(name, type, created_at) do
     %{

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -1,7 +1,7 @@
 defmodule RedisServerWrapperUnitTest do
   use ExUnit.Case, async: false
 
-  alias RedisServerWrapper.{Cli, Cluster, OSProcess, Sentinel, Server}
+  alias RedisServerWrapper.{Cli, Cluster, OSProcess, SecureFile, Sentinel, Server}
 
   setup do
     fixture_dir =
@@ -49,6 +49,7 @@ defmodule RedisServerWrapperUnitTest do
               *) echo "connection-refused"; exit 2 ;;
             esac
             ;;
+          *"SHOW_AUTH"*) printf 'auth=%s args=%s\n' "$REDISCLI_AUTH" "$args" ;;
           *"FAIL"*) echo "failure"; exit 2 ;;
           *) echo "$args" ;;
         esac
@@ -85,8 +86,15 @@ defmodule RedisServerWrapperUnitTest do
 
     assert {:ok, args} = Cli.run(cli, ["ECHO"])
     assert args =~ "-h ready -p 6380"
-    assert args =~ "-a secret --no-auth-warning"
     assert args =~ "--tls ECHO"
+    refute args =~ "secret"
+    refute args =~ " -a "
+
+    assert {:ok, auth} = Cli.run(cli, ["SHOW_AUTH"])
+    assert auth =~ "auth=secret"
+    assert auth =~ "args=-h ready -p 6380 --tls SHOW_AUTH"
+    refute auth =~ " -a "
+
     assert Cli.run!(cli, ["ECHO"]) =~ "--tls ECHO"
     assert Cli.ping(cli)
 
@@ -129,6 +137,41 @@ defmodule RedisServerWrapperUnitTest do
 
     assert {:error, "sentinel-error"} =
              Cli.sentinel_master(Cli.new(bin: bin, host: "error"), "mymaster")
+  end
+
+  test "private file helpers create, replace, and harden filesystem state", %{
+    fixture_dir: fixture_dir
+  } do
+    private_dir = Path.join(fixture_dir, "private")
+    private_file = Path.join(private_dir, "secret")
+    missing_file = Path.join(private_dir, "missing")
+
+    SecureFile.make_private_directory!(private_dir)
+    assert file_mode(private_dir) == 0o700
+
+    SecureFile.write_private!(private_file, "first")
+    assert File.read!(private_file) == "first"
+    assert file_mode(private_file) == 0o600
+
+    File.chmod!(private_file, 0o644)
+    SecureFile.write_private!(private_file, "second")
+    assert File.read!(private_file) == "second"
+    assert file_mode(private_file) == 0o600
+
+    SecureFile.atomic_write_private!(private_file, "atomic")
+    assert File.read!(private_file) == "atomic"
+    assert file_mode(private_file) == 0o600
+    assert Path.wildcard(Path.join(private_dir, ".*.tmp-*")) == []
+
+    File.chmod!(private_file, 0o644)
+    assert :ok = SecureFile.harden_private_file(private_file)
+    assert file_mode(private_file) == 0o600
+    assert :missing = SecureFile.harden_private_file(missing_file)
+
+    assert {:error, {:not_a_regular_file, :directory}} =
+             SecureFile.harden_private_file(private_dir)
+
+    assert_raise ArgumentError, fn -> SecureFile.write_private!(private_dir, "nope") end
   end
 
   test "top-level availability and version helpers cover every result shape", context do
@@ -309,6 +352,8 @@ defmodule RedisServerWrapperUnitTest do
     File.chmod!(path, 0o755)
     path
   end
+
+  defp file_mode(path), do: Bitwise.band(File.stat!(path).mode, 0o777)
 
   defp restore_path(nil), do: System.delete_env("PATH")
   defp restore_path(path), do: System.put_env("PATH", path)


### PR DESCRIPTION
## Summary

- pass Redis authentication through `REDISCLI_AUTH` instead of visible `-a` process arguments, including cluster creation
- generate Manager passwords from `:crypto.strong_rand_bytes/1`
- create wrapper-owned config/state directories as `0700` and credential-bearing files as `0600`
- launch Sentinel under a private umask so its automatic config rewrites remain `0600`
- redact credentials from default Manager output and add `Manager.credentials/1` for explicit retrieval
- percent-encode URL passwords and bracket IPv6 hosts
- atomically replace Manager state while serializing mutations across connected BEAM nodes
- preserve invalid state as a `.corrupt-*` recovery copy and avoid arbitrary atom creation during decoding
- document state concurrency and recovery behavior

## Security impact

Passwords no longer appear in `redis-cli` argv or normal Manager output. Plaintext credentials remain available where Redis requires them, but only in explicitly retrieved values and permission-restricted configuration/state files.

Manager writes are crash-safe at the file-replacement boundary. Independent, unconnected BEAM instances are documented as unsupported concurrent writers to the same state file.

## Verification

- `mix test --cover` — 74 tests, 90.87% total coverage
- `RedisServerWrapper.SecureFile` — 92.86% coverage
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`

Closes #57