### PR TITLE
fix: encode Redis configuration safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,11 @@ EVENT_STREAM_MODULE=/absolute/path/to/libredis_event_stream_module.so \
 
 ## Configuration
 
-All Redis configuration directives can be set via the `Config` struct options.
-Use the `:extra` option as an escape hatch for any directive not covered by
-the typed fields:
+All Redis configuration values are encoded as individual Redis tokens, including
+paths, passwords, module arguments, and `:extra` directives. Use a string for a
+single extra argument or a list for a multi-argument directive. Extras cannot
+override wrapper-owned lifecycle or transport settings such as `port`, `bind`,
+`daemonize`, `pidfile`, or `dir`.
 
 ```elixir
 RedisServerWrapper.start_server(
@@ -209,8 +211,21 @@ RedisServerWrapper.start_server(
   maxmemory_policy: "allkeys-lru",
   extra: [
     {"notify-keyspace-events", "KEA"},
+    {"client-output-buffer-limit", ["pubsub", "32mb", "8mb", "60"]},
     {"hz", "100"}
   ]
+)
+```
+
+`bind` may be one address, a whitespace-separated string, or a list of listen
+addresses. `control_host` independently selects the address used by
+`redis-cli`, readiness probes, replication, Cluster, and Sentinel:
+
+```elixir
+RedisServerWrapper.start_server(
+  port: 6400,
+  bind: ["127.0.0.1", "::1"],
+  control_host: "127.0.0.1"
 )
 ```
 

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -25,6 +25,8 @@ defmodule RedisServerWrapper.Cluster do
       because macOS AirPlay Receiver binds it by default, which causes
       confusing cluster-start failures on Mac.
     * `:bind` - bind address (default: "127.0.0.1")
+    * `:control_host` - address used by redis-cli and cluster announcements
+      (default: first bind address)
     * `:password` - Redis password (default: nil)
     * `:redis_server_bin` - redis-server binary path
     * `:redis_cli_bin` - redis-cli binary path
@@ -40,7 +42,7 @@ defmodule RedisServerWrapper.Cluster do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Server}
+  alias RedisServerWrapper.{Cli, Config, Server}
 
   require Logger
 
@@ -49,6 +51,7 @@ defmodule RedisServerWrapper.Cluster do
     :replicas_per_master,
     :base_port,
     :bind,
+    :control_host,
     :password,
     :redis_cli_bin,
     node_pids: [],
@@ -119,6 +122,11 @@ defmodule RedisServerWrapper.Cluster do
     replicas = Keyword.get(opts, :replicas_per_master, 0)
     base_port = Keyword.get(opts, :base_port, 7100)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
+
+    control_host =
+      Config.new(bind: bind, control_host: Keyword.get(opts, :control_host))
+      |> Config.control_host()
+
     password = Keyword.get(opts, :password)
 
     redis_server_bin =
@@ -136,6 +144,7 @@ defmodule RedisServerWrapper.Cluster do
       replicas_per_master: replicas,
       base_port: base_port,
       bind: bind,
+      control_host: control_host,
       password: password,
       redis_server_bin: redis_server_bin,
       redis_cli_bin: redis_cli_bin,
@@ -154,14 +163,14 @@ defmodule RedisServerWrapper.Cluster do
 
   @impl true
   def handle_call(:addr, _from, state) do
-    {:reply, "#{state.bind}:#{state.base_port}", state}
+    {:reply, format_addr(state.control_host, state.base_port), state}
   end
 
   def handle_call(:node_addrs, _from, state) do
     addrs =
       Enum.map(state.node_pids, fn pid ->
         info = Server.info(pid)
-        "#{info.host}:#{info.port}"
+        format_addr(info.host, info.port)
       end)
 
     {:reply, addrs, state}
@@ -198,11 +207,12 @@ defmodule RedisServerWrapper.Cluster do
       replicas_per_master: state.replicas_per_master,
       base_port: state.base_port,
       bind: state.bind,
+      control_host: state.control_host,
       total_nodes: length(state.node_pids),
       node_addrs:
         Enum.map(state.node_pids, fn pid ->
           node_info = Server.info(pid)
-          "#{node_info.host}:#{node_info.port}"
+          format_addr(node_info.host, node_info.port)
         end)
     }
 
@@ -257,6 +267,7 @@ defmodule RedisServerWrapper.Cluster do
     node_opts =
       Map.take(settings, [
         :bind,
+        :control_host,
         :password,
         :redis_server_bin,
         :redis_cli_bin,
@@ -279,12 +290,12 @@ defmodule RedisServerWrapper.Cluster do
     seed_cli =
       Cli.new(
         bin: settings.redis_cli_bin,
-        host: settings.bind,
+        host: settings.control_host,
         port: settings.base_port,
         password: settings.password
       )
 
-    node_addr_list = Enum.map(ports, &"#{settings.bind}:#{&1}")
+    node_addr_list = Enum.map(ports, &format_addr(settings.control_host, &1))
 
     case Cli.cluster_create(seed_cli, node_addr_list, settings.replicas_per_master) do
       {:ok, _output} ->
@@ -296,6 +307,7 @@ defmodule RedisServerWrapper.Cluster do
           replicas_per_master: settings.replicas_per_master,
           base_port: settings.base_port,
           bind: settings.bind,
+          control_host: settings.control_host,
           password: settings.password,
           redis_cli_bin: settings.redis_cli_bin,
           node_pids: node_pids
@@ -317,6 +329,7 @@ defmodule RedisServerWrapper.Cluster do
           [
             port: port,
             bind: node_opts.bind,
+            control_host: node_opts.control_host,
             password: node_opts.password,
             redis_server_bin: node_opts.redis_server_bin,
             redis_cli_bin: node_opts.redis_cli_bin,
@@ -346,7 +359,7 @@ defmodule RedisServerWrapper.Cluster do
   defp seed_cli(state) do
     Cli.new(
       bin: state.redis_cli_bin,
-      host: state.bind,
+      host: state.control_host,
       port: state.base_port,
       password: state.password
     )
@@ -354,6 +367,14 @@ defmodule RedisServerWrapper.Cluster do
 
   defp extra_to_opts([]), do: []
   defp extra_to_opts(extra), do: [extra: extra]
+
+  defp format_addr(host, port) do
+    if String.contains?(host, ":") do
+      "[#{host}]:#{port}"
+    else
+      "#{host}:#{port}"
+    end
+  end
 
   defp detach_servers(servers) do
     Enum.reduce_while(servers, :ok, fn server, :ok ->

--- a/lib/redis_server_wrapper/config.ex
+++ b/lib/redis_server_wrapper/config.ex
@@ -5,7 +5,8 @@ defmodule RedisServerWrapper.Config do
   Redis server configuration builder.
 
   Generates redis.conf content from a structured configuration.
-  Supports all common Redis directives with an escape hatch via `:extra` for anything else.
+  Supports common Redis directives plus token-safe `:extra` directives for
+  anything else. Every value is encoded as a Redis configuration token.
   """
 
   @type log_level :: :debug | :verbose | :notice | :warning
@@ -14,15 +15,23 @@ defmodule RedisServerWrapper.Config do
   @typedoc """
   A Redis module path, optionally paired with an argument vector.
 
-  Plain strings preserve the original raw `loadmodule` directive behavior.
-  Prefer `{path, args}` when arguments are needed so paths and arguments are
-  quoted safely in the generated config.
+  A plain string is one module-path token. Use `{path, args}` when arguments
+  are needed; paths and arguments are always quoted safely when required.
   """
   @type module_spec :: String.t() | {String.t(), [String.t()]}
+  @type bind_addresses :: String.t() | [String.t()]
+  @type extra_spec :: {String.t(), String.t() | [String.t()]}
+
+  # These validators intentionally defend the runtime struct boundary against
+  # values outside the public typespec.
+  @dialyzer {:nowarn_function, validate_save!: 1}
+  @dialyzer {:nowarn_function, validate_modules!: 1}
+  @dialyzer {:nowarn_function, validate_extra!: 1}
 
   @type t :: %__MODULE__{
           port: non_neg_integer(),
-          bind: String.t(),
+          bind: bind_addresses(),
+          control_host: String.t() | nil,
           password: String.t() | nil,
           loglevel: log_level(),
           logfile: String.t() | nil,
@@ -61,11 +70,12 @@ defmodule RedisServerWrapper.Config do
           # Modules
           loadmodule: [module_spec()],
           # Catch-all
-          extra: [{String.t(), String.t()}]
+          extra: [extra_spec()]
         }
 
   defstruct port: 6379,
             bind: "127.0.0.1",
+            control_host: nil,
             password: nil,
             loglevel: :notice,
             logfile: nil,
@@ -112,8 +122,40 @@ defmodule RedisServerWrapper.Config do
   @spec new(keyword()) :: t()
   def new(opts \\ []) do
     config = struct!(__MODULE__, opts)
-    validate_modules!(config.loadmodule)
+    validate!(config)
     config
+  end
+
+  @doc """
+  Returns the address used by `redis-cli` and lifecycle probes.
+
+  `:bind` controls Redis listen addresses. Set `:control_host` when Redis
+  listens on multiple addresses or on a wildcard address.
+  """
+  @spec control_host(t()) :: String.t()
+  def control_host(%__MODULE__{control_host: host}) when is_binary(host), do: host
+
+  def control_host(%__MODULE__{bind: bind}) do
+    bind
+    |> bind_tokens()
+    |> List.first()
+    |> normalize_control_host()
+  end
+
+  @doc "Returns normalized Redis listen-address tokens."
+  @spec listen_addresses(t()) :: [String.t()]
+  def listen_addresses(%__MODULE__{bind: bind}), do: bind_tokens(bind)
+
+  @doc """
+  Encodes one Redis configuration directive from an argument vector.
+
+  This is also used by the Sentinel configuration generator so it follows the
+  same quoting and escaping rules as `redis.conf`.
+  """
+  @spec directive(String.t(), [term()]) :: String.t()
+  def directive(key, values) when is_binary(key) and is_list(values) do
+    validate_directive_key!(key)
+    Enum.join([key | Enum.map(values, &encode_token/1)], " ")
   end
 
   @doc """
@@ -123,7 +165,7 @@ defmodule RedisServerWrapper.Config do
   def to_config_string(%__MODULE__{} = config) do
     []
     |> emit("port", config.port)
-    |> emit("bind", config.bind)
+    |> emit("bind", bind_tokens(config.bind))
     |> emit_if("requirepass", config.password)
     |> emit("loglevel", config.loglevel)
     |> emit_if("logfile", config.logfile)
@@ -152,17 +194,21 @@ defmodule RedisServerWrapper.Config do
 
   # Directive emitters
 
-  defp emit(acc, key, value), do: ["#{key} #{value}" | acc]
+  defp emit(acc, key, values) when is_list(values) do
+    [directive(key, values) | acc]
+  end
+
+  defp emit(acc, key, value), do: emit(acc, key, [value])
 
   defp emit_if(acc, _key, nil), do: acc
   defp emit_if(acc, key, value), do: emit(acc, key, value)
 
   defp emit_save(acc, :default), do: acc
-  defp emit_save(acc, :disabled), do: ["save \"\"" | acc]
+  defp emit_save(acc, :disabled), do: emit(acc, "save", [""])
 
   defp emit_save(acc, policies) when is_list(policies) do
     Enum.reduce(policies, acc, fn {seconds, changes}, acc ->
-      ["save #{seconds} #{changes}" | acc]
+      emit(acc, "save", [seconds, changes])
     end)
   end
 
@@ -183,7 +229,7 @@ defmodule RedisServerWrapper.Config do
     {host, port} = config.replicaof
 
     acc
-    |> emit("replicaof", "#{host} #{port}")
+    |> emit("replicaof", [host, port])
     |> emit_if("masterauth", config.masterauth)
   end
 
@@ -205,23 +251,183 @@ defmodule RedisServerWrapper.Config do
     Enum.reduce(modules, acc, &emit_module/2)
   end
 
-  # Preserve the original raw-string form for backwards compatibility. This
-  # allows existing callers that put both the path and arguments in one string
-  # to keep working unchanged.
-  defp emit_module(module, acc) when is_binary(module), do: ["loadmodule #{module}" | acc]
-
-  defp emit_module({path, args}, acc) do
-    directive =
-      [path | args]
-      |> Enum.map_join(" ", &quote_module_token/1)
-
-    ["loadmodule #{directive}" | acc]
-  end
+  defp emit_module(module, acc) when is_binary(module), do: emit(acc, "loadmodule", [module])
+  defp emit_module({path, args}, acc), do: emit(acc, "loadmodule", [path | args])
 
   defp emit_extra(acc, []), do: acc
 
   defp emit_extra(acc, extras) do
-    Enum.reduce(extras, acc, fn {key, value}, acc -> ["#{key} #{value}" | acc] end)
+    Enum.reduce(extras, acc, fn
+      {key, values}, acc when is_list(values) -> emit(acc, key, values)
+      {key, value}, acc -> emit(acc, key, [value])
+    end)
+  end
+
+  @reserved_directives MapSet.new(~w(
+    port bind requirepass loglevel logfile daemonize pidfile dir save
+    appendonly appendfsync maxmemory maxmemory-policy tcp-backlog timeout
+    tcp-keepalive unixsocket unixsocketperm tls-port tls-cert-file
+    tls-key-file tls-ca-cert-file tls-auth-clients replicaof masterauth
+    cluster-enabled cluster-config-file cluster-node-timeout
+    cluster-announce-hostname cluster-announce-port cluster-announce-bus-port
+    loadmodule
+  ))
+
+  defp validate!(config) do
+    validate_enum!(:loglevel, config.loglevel, [:debug, :verbose, :notice, :warning])
+    validate_enum!(:appendfsync, config.appendfsync, [:always, :everysec, :no])
+    validate_boolean!(:daemonize, config.daemonize)
+    validate_boolean!(:appendonly, config.appendonly)
+    validate_boolean!(:cluster_enabled, config.cluster_enabled)
+    validate_port!(:port, config.port)
+
+    Enum.each(
+      [
+        tcp_backlog: config.tcp_backlog,
+        timeout: config.timeout,
+        tcp_keepalive: config.tcp_keepalive,
+        cluster_node_timeout: config.cluster_node_timeout
+      ],
+      fn {field, value} -> validate_optional_non_negative_integer!(field, value) end
+    )
+
+    Enum.each(
+      [
+        tls_port: config.tls_port,
+        cluster_announce_port: config.cluster_announce_port,
+        cluster_announce_bus_port: config.cluster_announce_bus_port
+      ],
+      fn {field, value} -> validate_optional_port!(field, value) end
+    )
+
+    validate_bind!(config.bind)
+    validate_control_host!(config)
+
+    Enum.each(
+      [
+        password: config.password,
+        logfile: config.logfile,
+        pidfile: config.pidfile,
+        dir: config.dir,
+        maxmemory: config.maxmemory,
+        maxmemory_policy: config.maxmemory_policy,
+        unixsocket: config.unixsocket,
+        unixsocketperm: config.unixsocketperm,
+        tls_cert_file: config.tls_cert_file,
+        tls_key_file: config.tls_key_file,
+        tls_ca_cert_file: config.tls_ca_cert_file,
+        tls_auth_clients: config.tls_auth_clients,
+        masterauth: config.masterauth,
+        cluster_config_file: config.cluster_config_file,
+        cluster_announce_hostname: config.cluster_announce_hostname
+      ],
+      fn {field, value} -> validate_optional_binary!(field, value) end
+    )
+
+    validate_save!(config.save)
+    validate_replicaof!(config.replicaof)
+    validate_modules!(config.loadmodule)
+    validate_extra!(config.extra)
+  end
+
+  defp validate_enum!(field, value, allowed) do
+    unless value in allowed do
+      raise ArgumentError, ":#{field} must be one of #{inspect(allowed)}, got: #{inspect(value)}"
+    end
+  end
+
+  defp validate_boolean!(_field, value) when is_boolean(value), do: :ok
+
+  defp validate_boolean!(field, value) do
+    raise ArgumentError, ":#{field} must be a boolean, got: #{inspect(value)}"
+  end
+
+  defp validate_port!(_field, value) when is_integer(value) and value in 1..65_535, do: :ok
+
+  defp validate_port!(field, value) do
+    raise ArgumentError, ":#{field} must be an integer from 1 to 65535, got: #{inspect(value)}"
+  end
+
+  defp validate_optional_port!(_field, nil), do: :ok
+  defp validate_optional_port!(field, value), do: validate_port!(field, value)
+
+  defp validate_optional_non_negative_integer!(_field, nil), do: :ok
+
+  defp validate_optional_non_negative_integer!(_field, value)
+       when is_integer(value) and value >= 0,
+       do: :ok
+
+  defp validate_optional_non_negative_integer!(field, value) do
+    raise ArgumentError, ":#{field} must be a non-negative integer, got: #{inspect(value)}"
+  end
+
+  defp validate_optional_binary!(_field, nil), do: :ok
+  defp validate_optional_binary!(_field, value) when is_binary(value), do: :ok
+
+  defp validate_optional_binary!(field, value) do
+    raise ArgumentError, ":#{field} must be a string or nil, got: #{inspect(value)}"
+  end
+
+  defp validate_bind!(bind) do
+    bind
+    |> bind_tokens()
+    |> validate_bind_tokens!()
+  end
+
+  defp validate_bind_tokens!([]), do: raise(ArgumentError, ":bind must contain an address")
+  defp validate_bind_tokens!(addresses), do: Enum.each(addresses, &validate_bind_address!/1)
+
+  defp validate_bind_address!(address) when is_binary(address) and address != "", do: :ok
+
+  defp validate_bind_address!(_address) do
+    raise ArgumentError, ":bind addresses must be non-empty strings"
+  end
+
+  defp validate_control_host!(config) do
+    host = control_host(config)
+
+    cond do
+      not is_binary(host) or host == "" or Regex.match?(~r/\s/u, host) ->
+        raise ArgumentError, ":control_host must resolve to one non-empty address"
+
+      is_nil(config.control_host) and host in ["*", "::*", "0.0.0.0", "::"] ->
+        raise ArgumentError,
+              ":control_host is required when the first bind address is a wildcard"
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_save!(:default), do: :ok
+  defp validate_save!(:disabled), do: :ok
+
+  defp validate_save!(policies) when is_list(policies) do
+    Enum.each(policies, fn
+      {seconds, changes}
+      when is_integer(seconds) and seconds > 0 and is_integer(changes) and changes > 0 ->
+        :ok
+
+      policy ->
+        raise ArgumentError,
+              ":save entries must be {positive_seconds, positive_changes}, got: " <>
+                inspect(policy)
+    end)
+  end
+
+  defp validate_save!(value) do
+    raise ArgumentError,
+          ":save must be :default, :disabled, or a policy list, got: #{inspect(value)}"
+  end
+
+  defp validate_replicaof!(nil), do: :ok
+
+  defp validate_replicaof!({host, port}) when is_binary(host) and host != "" do
+    validate_port!(:replicaof_port, port)
+  end
+
+  defp validate_replicaof!(value) do
+    raise ArgumentError, ":replicaof must be {host, port} or nil, got: #{inspect(value)}"
   end
 
   defp validate_modules!(modules) when is_list(modules) do
@@ -249,16 +455,77 @@ defmodule RedisServerWrapper.Config do
             inspect(value)
   end
 
-  defp quote_module_token(value) do
+  defp validate_extra!(extras) when is_list(extras) do
+    Enum.each(extras, fn
+      {key, value} when is_binary(value) ->
+        validate_extra_key!(key)
+
+      {key, values} when is_list(values) ->
+        validate_extra_key!(key)
+
+        unless values != [] and Enum.all?(values, &is_binary/1) do
+          invalid_extra_spec!({key, values})
+        end
+
+      extra ->
+        invalid_extra_spec!(extra)
+    end)
+  end
+
+  defp validate_extra!(value), do: invalid_extra_spec!(value)
+
+  defp validate_extra_key!(key) when is_binary(key) do
+    normalized = String.downcase(key)
+    validate_directive_key!(normalized)
+
+    if MapSet.member?(@reserved_directives, normalized) do
+      raise ArgumentError,
+            ":extra cannot override wrapper-owned directive #{inspect(normalized)}"
+    end
+  end
+
+  defp validate_extra_key!(key), do: invalid_extra_spec!({key, []})
+
+  defp invalid_extra_spec!(value) do
+    raise ArgumentError,
+          ":extra must be a list of {directive, value_or_argument_vector} tuples, got: " <>
+            inspect(value)
+  end
+
+  defp validate_directive_key!(key) do
+    unless Regex.match?(~r/\A[a-z][a-z0-9-]*\z/, String.downcase(key)) do
+      raise ArgumentError, "invalid Redis directive name: #{inspect(key)}"
+    end
+  end
+
+  defp encode_token(value) do
+    value = to_string(value)
+
+    if value != "" and Regex.match?(~r/\A[^\s"\\#]+\z/u, value) do
+      value
+    else
+      quote_token(value)
+    end
+  end
+
+  defp quote_token(value) do
     escaped =
       value
       |> String.replace("\\", "\\\\")
       |> String.replace("\"", "\\\"")
       |> String.replace("\n", "\\n")
       |> String.replace("\r", "\\r")
+      |> String.replace("\t", "\\t")
 
     ~s("#{escaped}")
   end
+
+  defp bind_tokens(bind) when is_binary(bind), do: String.split(bind)
+  defp bind_tokens(bind) when is_list(bind), do: bind
+  defp bind_tokens(_bind), do: []
+
+  defp normalize_control_host("-" <> host), do: host
+  defp normalize_control_host(host), do: host
 
   defp yn(true), do: "yes"
   defp yn(false), do: "no"

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -54,6 +54,7 @@ defmodule RedisServerWrapper.Manager do
     * `:port` - Redis port (default: 6379)
     * `:password` - Redis password (auto-generated if omitted, pass `nil` for no auth)
     * `:bind` - bind address (default: "127.0.0.1")
+    * `:control_host` - address used for client and lifecycle operations
     * `:persist` - enable persistence (default: false)
     * `:maxmemory` - memory limit (e.g., "256mb")
     * `:loadmodule` - modules to load; accepts paths or `{path, [args]}` tuples
@@ -70,6 +71,7 @@ defmodule RedisServerWrapper.Manager do
     password = resolve_password(opts)
     port = Keyword.get(opts, :port, 6379)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
+    control_host = Keyword.get(opts, :control_host)
     persist = Keyword.get(opts, :persist, false)
     maxmemory = Keyword.get(opts, :maxmemory)
     loadmodule = Keyword.get(opts, :loadmodule, [])
@@ -82,6 +84,7 @@ defmodule RedisServerWrapper.Manager do
         [
           port: port,
           bind: bind,
+          control_host: control_host,
           password: password,
           save: if(persist, do: :default, else: :disabled),
           appendonly: persist,
@@ -101,11 +104,11 @@ defmodule RedisServerWrapper.Manager do
             name: name,
             type: :basic,
             created_at: DateTime.utc_now() |> DateTime.to_iso8601(),
-            bind: bind,
+            bind: info.host,
             ports: [port],
             pids: [info.pid],
             password: password,
-            url: build_url(bind, port, password),
+            url: build_url(info.host, port, password),
             metadata: %{
               persist: persist,
               maxmemory: maxmemory,
@@ -134,6 +137,7 @@ defmodule RedisServerWrapper.Manager do
     * `:base_port` - starting port (default: 7100)
     * `:password` - Redis password (auto-generated if omitted)
     * `:bind` - bind address (default: "127.0.0.1")
+    * `:control_host` - address used for client and cluster operations
     * `:loadmodule` - modules loaded into every cluster node
   """
   @spec start_cluster(keyword()) :: {:ok, instance()} | {:error, term()}
@@ -149,6 +153,7 @@ defmodule RedisServerWrapper.Manager do
     replicas = Keyword.get(opts, :replicas_per_master, 0)
     base_port = Keyword.get(opts, :base_port, 7100)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
+    control_host = Keyword.get(opts, :control_host)
     loadmodule = Keyword.get(opts, :loadmodule, [])
 
     if Map.has_key?(state.instances, name) do
@@ -159,6 +164,7 @@ defmodule RedisServerWrapper.Manager do
         replicas_per_master: replicas,
         base_port: base_port,
         bind: bind,
+        control_host: control_host,
         password: password,
         managed: false,
         loadmodule: loadmodule
@@ -182,11 +188,11 @@ defmodule RedisServerWrapper.Manager do
             name: name,
             type: :cluster,
             created_at: DateTime.utc_now() |> DateTime.to_iso8601(),
-            bind: bind,
+            bind: cluster_info.control_host,
             ports: ports,
             pids: os_pids,
             password: password,
-            url: build_url(bind, base_port, password),
+            url: build_url(cluster_info.control_host, base_port, password),
             metadata: %{
               masters: masters,
               replicas_per_master: replicas
@@ -233,6 +239,7 @@ defmodule RedisServerWrapper.Manager do
     quorum = Keyword.get(opts, :quorum, min(2, num_sentinels))
     sentinel_base_port = Keyword.get(opts, :sentinel_base_port, 26_389)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
+    control_host = Keyword.get(opts, :control_host)
     loadmodule = Keyword.get(opts, :loadmodule, [])
 
     if Map.has_key?(state.instances, name) do
@@ -245,6 +252,7 @@ defmodule RedisServerWrapper.Manager do
         quorum: quorum,
         sentinel_base_port: sentinel_base_port,
         bind: bind,
+        control_host: control_host,
         password: password,
         managed: false,
         loadmodule: loadmodule
@@ -281,11 +289,11 @@ defmodule RedisServerWrapper.Manager do
             name: name,
             type: :sentinel,
             created_at: DateTime.utc_now() |> DateTime.to_iso8601(),
-            bind: bind,
+            bind: sen_info.control_host,
             ports: all_redis_ports ++ sentinel_ports,
             pids: redis_pids ++ sentinel_pids,
             password: password,
-            url: build_url(bind, master_port, password),
+            url: build_url(sen_info.control_host, master_port, password),
             metadata: %{
               master_name: sen_info.master_name,
               master_port: master_port,

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -26,6 +26,8 @@ defmodule RedisServerWrapper.Sentinel do
     * `:down_after_ms` - down-after-milliseconds (default: 5000)
     * `:failover_timeout_ms` - failover timeout (default: 10_000)
     * `:bind` - bind address (default: "127.0.0.1")
+    * `:control_host` - address used by redis-cli, replication, and Sentinel
+      monitoring (default: first bind address)
     * `:password` - Redis password
     * `:redis_server_bin` - redis-server binary path
     * `:redis_cli_bin` - redis-cli binary path
@@ -41,7 +43,7 @@ defmodule RedisServerWrapper.Sentinel do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, OSProcess, SecureFile, Server}
+  alias RedisServerWrapper.{Cli, Config, OSProcess, SecureFile, Server}
 
   require Logger
 
@@ -49,6 +51,7 @@ defmodule RedisServerWrapper.Sentinel do
     :master_name,
     :master_port,
     :bind,
+    :control_host,
     :password,
     :redis_cli_bin,
     :master_pid,
@@ -130,6 +133,11 @@ defmodule RedisServerWrapper.Sentinel do
     down_after_ms = Keyword.get(opts, :down_after_ms, 5000)
     failover_timeout_ms = Keyword.get(opts, :failover_timeout_ms, 10_000)
     bind = Keyword.get(opts, :bind, "127.0.0.1")
+
+    control_host =
+      Config.new(bind: bind, control_host: Keyword.get(opts, :control_host))
+      |> Config.control_host()
+
     password = Keyword.get(opts, :password)
 
     redis_server_bin =
@@ -142,6 +150,7 @@ defmodule RedisServerWrapper.Sentinel do
 
     node_opts = %{
       bind: bind,
+      control_host: control_host,
       password: password,
       redis_server_bin: redis_server_bin,
       redis_cli_bin: redis_cli_bin,
@@ -175,6 +184,7 @@ defmodule RedisServerWrapper.Sentinel do
              master_name: master_name,
              master_port: master_port,
              bind: bind,
+             control_host: control_host,
              password: password,
              quorum: quorum,
              down_after_ms: down_after_ms,
@@ -192,6 +202,7 @@ defmodule RedisServerWrapper.Sentinel do
         master_name: master_name,
         master_port: master_port,
         bind: bind,
+        control_host: control_host,
         password: password,
         redis_cli_bin: redis_cli_bin,
         master_pid: master_pid,
@@ -212,21 +223,23 @@ defmodule RedisServerWrapper.Sentinel do
 
   @impl true
   def handle_call(:master_addr, _from, state) do
-    {:reply, "#{state.bind}:#{state.master_port}", state}
+    {:reply, format_addr(state.control_host, state.master_port), state}
   end
 
   def handle_call(:sentinel_addrs, _from, state) do
-    addrs = Enum.map(state.sentinel_ports, &"#{state.bind}:#{&1}")
+    addrs = Enum.map(state.sentinel_ports, &format_addr(state.control_host, &1))
     {:reply, addrs, state}
   end
 
   def handle_call(:info, _from, state) do
     info = %{
       master_name: state.master_name,
-      master_addr: "#{state.bind}:#{state.master_port}",
+      bind: state.bind,
+      control_host: state.control_host,
+      master_addr: format_addr(state.control_host, state.master_port),
       replicas: state.num_replicas,
       sentinels: state.num_sentinels,
-      sentinel_addrs: Enum.map(state.sentinel_ports, &"#{state.bind}:#{&1}")
+      sentinel_addrs: Enum.map(state.sentinel_ports, &format_addr(state.control_host, &1))
     }
 
     {:reply, info, state}
@@ -235,7 +248,7 @@ defmodule RedisServerWrapper.Sentinel do
   def handle_call(:healthy?, _from, state) do
     result =
       Enum.any?(state.sentinel_ports, fn port ->
-        cli = Cli.new(bin: state.redis_cli_bin, host: state.bind, port: port)
+        cli = Cli.new(bin: state.redis_cli_bin, host: state.control_host, port: port)
 
         case Cli.sentinel_master(cli, state.master_name) do
           {:ok, info} ->
@@ -258,7 +271,7 @@ defmodule RedisServerWrapper.Sentinel do
   def handle_call(:poke, _from, state) do
     result =
       Enum.find_value(state.sentinel_ports, {:error, :no_reachable_sentinel}, fn port ->
-        cli = Cli.new(bin: state.redis_cli_bin, host: state.bind, port: port)
+        cli = Cli.new(bin: state.redis_cli_bin, host: state.control_host, port: port)
 
         case Cli.sentinel_master(cli, state.master_name) do
           {:ok, info} -> {:ok, info}
@@ -324,6 +337,7 @@ defmodule RedisServerWrapper.Sentinel do
     Server.start_link(
       port: port,
       bind: node_opts.bind,
+      control_host: node_opts.control_host,
       password: node_opts.password,
       redis_server_bin: node_opts.redis_server_bin,
       redis_cli_bin: node_opts.redis_cli_bin,
@@ -344,9 +358,10 @@ defmodule RedisServerWrapper.Sentinel do
         opts = [
           port: port,
           bind: node_opts.bind,
+          control_host: node_opts.control_host,
           password: node_opts.password,
           masterauth: node_opts.password,
-          replicaof: {node_opts.bind, master_port},
+          replicaof: {node_opts.control_host, master_port},
           redis_server_bin: node_opts.redis_server_bin,
           redis_cli_bin: node_opts.redis_cli_bin,
           timeout: node_opts.timeout,
@@ -413,7 +428,7 @@ defmodule RedisServerWrapper.Sentinel do
       conf_path,
       node_dir,
       opts.redis_cli_bin,
-      opts.bind,
+      opts.control_host,
       port,
       opts.timeout
     )
@@ -422,6 +437,7 @@ defmodule RedisServerWrapper.Sentinel do
   defp generate_sentinel_conf(opts, dir, port) do
     %{
       bind: bind,
+      control_host: control_host,
       master_name: master_name,
       master_port: master_port,
       password: password,
@@ -430,22 +446,24 @@ defmodule RedisServerWrapper.Sentinel do
       failover_timeout_ms: failover_timeout_ms
     } = opts
 
+    listen_addresses = Config.new(bind: bind) |> Config.listen_addresses()
+
     lines = [
-      "port #{port}",
-      "bind #{bind}",
-      "daemonize yes",
-      "pidfile #{Path.join(dir, "sentinel.pid")}",
-      "logfile #{Path.join(dir, "sentinel.log")}",
-      "dir #{dir}",
-      "sentinel monitor #{master_name} #{bind} #{master_port} #{quorum}",
-      "sentinel down-after-milliseconds #{master_name} #{down_after_ms}",
-      "sentinel failover-timeout #{master_name} #{failover_timeout_ms}",
-      "sentinel parallel-syncs #{master_name} 1"
+      Config.directive("port", [port]),
+      Config.directive("bind", listen_addresses),
+      Config.directive("daemonize", ["yes"]),
+      Config.directive("pidfile", [Path.join(dir, "sentinel.pid")]),
+      Config.directive("logfile", [Path.join(dir, "sentinel.log")]),
+      Config.directive("dir", [dir]),
+      Config.directive("sentinel", ["monitor", master_name, control_host, master_port, quorum]),
+      Config.directive("sentinel", ["down-after-milliseconds", master_name, down_after_ms]),
+      Config.directive("sentinel", ["failover-timeout", master_name, failover_timeout_ms]),
+      Config.directive("sentinel", ["parallel-syncs", master_name, 1])
     ]
 
     lines =
       if password do
-        lines ++ ["sentinel auth-pass #{master_name} #{password}"]
+        lines ++ [Config.directive("sentinel", ["auth-pass", master_name, password])]
       else
         lines
       end
@@ -569,6 +587,14 @@ defmodule RedisServerWrapper.Sentinel do
 
   defp ports_from(_base_port, 0), do: []
   defp ports_from(base_port, count), do: Enum.map(0..(count - 1), &(base_port + &1))
+
+  defp format_addr(host, port) do
+    if String.contains?(host, ":") do
+      "[#{host}]:#{port}"
+    else
+      "#{host}:#{port}"
+    end
+  end
 
   defp detach_servers(servers) do
     Enum.reduce_while(servers, :ok, fn server, :ok ->

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -211,7 +211,8 @@ defmodule RedisServerWrapper.Server do
 
   def handle_call(:info, _from, state) do
     info = %{
-      host: state.config.bind,
+      host: Config.control_host(state.config),
+      bind: state.config.bind,
       port: state.config.port,
       password: state.config.password,
       pid: state.pid,
@@ -335,7 +336,7 @@ defmodule RedisServerWrapper.Server do
 
   # Port-based: redis-server runs in the foreground, tied to the BEAM.
   defp start_managed(config, redis_server_bin, redis_cli_bin, timeout) do
-    with :ok <- check_port_available(config.bind, config.port) do
+    with :ok <- check_port_available(Config.control_host(config), config.port) do
       do_start_managed(config, redis_server_bin, redis_cli_bin, timeout)
     end
   end
@@ -370,7 +371,7 @@ defmodule RedisServerWrapper.Server do
     cli =
       Cli.new(
         bin: redis_cli_bin,
-        host: config.bind,
+        host: Config.control_host(config),
         port: config.port,
         password: config.password
       )
@@ -412,7 +413,7 @@ defmodule RedisServerWrapper.Server do
   # where terminate/2 never runs.
   defp start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout) do
     if forcola_available?() do
-      with :ok <- check_port_available(config.bind, config.port) do
+      with :ok <- check_port_available(Config.control_host(config), config.port) do
         do_start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout)
       end
     else
@@ -442,7 +443,7 @@ defmodule RedisServerWrapper.Server do
     cli =
       Cli.new(
         bin: redis_cli_bin,
-        host: config.bind,
+        host: Config.control_host(config),
         port: config.port,
         password: config.password
       )
@@ -494,7 +495,7 @@ defmodule RedisServerWrapper.Server do
   # wanted instances. If the port is held, check_port_available returns
   # {:error, {:port_in_use, ...}} and the caller decides what to do.
   defp start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout) do
-    with :ok <- check_port_available(config.bind, config.port) do
+    with :ok <- check_port_available(Config.control_host(config), config.port) do
       do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout)
     end
   end
@@ -524,7 +525,7 @@ defmodule RedisServerWrapper.Server do
         cli =
           Cli.new(
             bin: redis_cli_bin,
-            host: config.bind,
+            host: Config.control_host(config),
             port: config.port,
             password: config.password
           )

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -83,10 +83,67 @@ defmodule RedisServerWrapperTest do
     end
 
     test "extra directives" do
-      config = Config.new(extra: [{"maxmemory-policy", "allkeys-lru"}, {"hz", "20"}])
+      config =
+        Config.new(
+          extra: [
+            {"notify-keyspace-events", "KEA"},
+            {"client-output-buffer-limit", ["pubsub", "32mb", "8mb", "60"]},
+            {"hz", "20"}
+          ]
+        )
+
       output = Config.to_config_string(config)
-      assert output =~ "maxmemory-policy allkeys-lru"
+      assert output =~ "notify-keyspace-events KEA"
+      assert output =~ "client-output-buffer-limit pubsub 32mb 8mb 60"
       assert output =~ "hz 20"
+    end
+
+    test "quotes and escapes every directive token safely" do
+      config =
+        Config.new(
+          password: "space \"quote\" \\ slash\nnext#",
+          logfile: "/tmp/redis logs/quoted\"name.log",
+          replicaof: {"replica host", 6379},
+          extra: [{"acl-pubsub-default", "resetchannels\nallchannels"}]
+        )
+
+      output = Config.to_config_string(config)
+
+      assert output =~ ~s(requirepass "space \\"quote\\" \\\\ slash\\nnext#")
+      assert output =~ ~s(logfile "/tmp/redis logs/quoted\\"name.log")
+      assert output =~ ~s(replicaof "replica host" 6379)
+      assert output =~ ~s(acl-pubsub-default "resetchannels\\nallchannels")
+      refute output =~ "slash\nnext"
+    end
+
+    test "supports multiple bind addresses with a separate control host" do
+      config = Config.new(bind: ["127.0.0.1", "::1"], control_host: "::1")
+
+      assert Config.to_config_string(config) =~ "bind 127.0.0.1 ::1"
+      assert Config.listen_addresses(config) == ["127.0.0.1", "::1"]
+      assert Config.control_host(config) == "::1"
+    end
+
+    test "rejects reserved extras and invalid typed values" do
+      assert_raise ArgumentError, ~r/cannot override.*port/, fn ->
+        Config.new(extra: [{"port", "9999"}])
+      end
+
+      assert_raise ArgumentError, ~r/cannot override.*daemonize/, fn ->
+        Config.new(extra: [{"daemonize", ["yes"]}])
+      end
+
+      assert_raise ArgumentError, ~r/:port must be/, fn -> Config.new(port: 70_000) end
+      assert_raise ArgumentError, ~r/:loglevel must be/, fn -> Config.new(loglevel: :loud) end
+      assert_raise ArgumentError, ~r/:appendonly must be/, fn -> Config.new(appendonly: "yes") end
+
+      assert_raise ArgumentError, ~r/:save entries must be/, fn ->
+        Config.new(save: [{0, 1}])
+      end
+
+      assert_raise ArgumentError, ~r/argument_vector/, fn ->
+        Config.new(extra: [{"hz", ["10", :unsafe]}])
+      end
     end
 
     test "module paths and structured module arguments" do
@@ -100,10 +157,10 @@ defmodule RedisServerWrapperTest do
 
       output = Config.to_config_string(config)
 
-      assert output =~ "loadmodule /modules/legacy.so events expired"
+      assert output =~ ~s(loadmodule "/modules/legacy.so events expired")
 
       assert output =~
-               ~s(loadmodule "/modules/event stream.so" "events" "expired,set" "maxlen" "10000")
+               ~s(loadmodule "/modules/event stream.so" events expired,set maxlen 10000)
     end
 
     test "rejects invalid module specifications" do
@@ -164,7 +221,8 @@ defmodule RedisServerWrapperTest do
     end
 
     test "start with password" do
-      {:ok, server} = Server.start_link(port: 6401, password: "testsecret")
+      password = "test secret\"\\\n#"
+      {:ok, server} = Server.start_link(port: 6401, password: password)
 
       assert Server.ping(server)
       assert {:ok, "OK"} = Server.run(server, ["SET", "k", "v"])
@@ -176,6 +234,24 @@ defmodule RedisServerWrapperTest do
 
       Server.stop(server)
       Process.sleep(500)
+    end
+
+    test "multiple listen addresses use an explicit control host" do
+      {:ok, server} =
+        Server.start_link(
+          port: 6405,
+          bind: ["127.0.0.1", "::1"],
+          control_host: "127.0.0.1"
+        )
+
+      try do
+        assert Server.ping(server)
+        assert Server.info(server).bind == ["127.0.0.1", "::1"]
+        assert Server.info(server).host == "127.0.0.1"
+        assert Server.cli(server).host == "127.0.0.1"
+      after
+        Server.stop(server)
+      end
     end
 
     test "detach prevents shutdown on stop (unmanaged)" do
@@ -794,10 +870,18 @@ defmodule RedisServerWrapperTest do
 
     @tag timeout: 30_000
     test "start 3-master cluster, verify health, stop" do
-      {:ok, cluster} = RedisServerWrapper.start_cluster(masters: 3, base_port: 7100)
+      {:ok, cluster} =
+        RedisServerWrapper.start_cluster(
+          masters: 3,
+          base_port: 7100,
+          bind: ["127.0.0.1", "::1"],
+          control_host: "127.0.0.1"
+        )
 
       assert Cluster.all_alive?(cluster)
       assert wait_until(fn -> Cluster.healthy?(cluster) end)
+      assert Cluster.addr(cluster) == "127.0.0.1:7100"
+      assert Cluster.info(cluster).bind == ["127.0.0.1", "::1"]
 
       info = Cluster.info(cluster)
       assert info.masters == 3
@@ -857,7 +941,10 @@ defmodule RedisServerWrapperTest do
           replicas: 0,
           sentinels: 1,
           sentinel_base_port: 26_510,
-          quorum: 1
+          quorum: 1,
+          bind: ["127.0.0.1", "::1"],
+          control_host: "127.0.0.1",
+          password: "sentinel secret\"\\\n#"
         )
 
       try do


### PR DESCRIPTION
## Summary

- encode every Redis and Sentinel configuration value as a safe Redis token, including whitespace, quotes, backslashes, newlines, and empty values
- treat plain module paths as one token and keep module arguments structured as `{path, [args]}`
- support single-argument and argument-vector `:extra` directives
- reject extras that try to override wrapper-owned lifecycle, transport, authentication, persistence, cluster, or module directives
- validate typed enums, booleans, ports, timeouts, save policies, replication targets, bind addresses, modules, and extras before writing config
- add `:control_host` so Redis listen addresses are independent from redis-cli, readiness, replication, Cluster, and Sentinel addresses
- support list and whitespace-separated multi-address binds across Server, Cluster, Sentinel, and Manager
- bracket IPv6 addresses where host/port strings require it
- document the safe configuration and control-host surface

## Root cause

Typed string fields and raw extras were interpolated directly into config lines. Values containing Redis token delimiters could become invalid or inject additional directives. Extras could also override fields the wrapper continued to use for readiness and teardown, causing the generated config and lifecycle state to disagree. Multi-address `bind` values were incorrectly reused as one redis-cli hostname.

## Verification

- `mix test --cover` — 78 tests, 90.55% total coverage
- `RedisServerWrapper.Config` — 90.64% coverage
- real Redis startup with spaces, quotes, backslashes, newlines, and `#` in credentials
- multi-address standalone, Cluster, and Sentinel integration tests
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`

Closes #55