### PR TITLE
CI: define and test the supported Redis version matrix

### DIFF
--- a/.github/scripts/build-redis.sh
+++ b/.github/scripts/build-redis.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="$1"
+prefix="$2"
+
+if [[ -x "${prefix}/bin/redis-server" && -x "${prefix}/bin/redis-cli" ]]; then
+  exit 0
+fi
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "${work_dir}"' EXIT
+
+curl --fail --location --silent --show-error \
+  "https://download.redis.io/releases/redis-${version}.tar.gz" \
+  --output "${work_dir}/redis.tar.gz"
+
+tar -xzf "${work_dir}/redis.tar.gz" --directory "${work_dir}"
+make -C "${work_dir}/redis-${version}" -j"$(nproc)"
+
+mkdir -p "${prefix}/bin" "${prefix}/include"
+cp "${work_dir}/redis-${version}/src/redis-server" "${prefix}/bin/"
+cp "${work_dir}/redis-${version}/src/redis-cli" "${prefix}/bin/"
+cp "${work_dir}/redis-${version}/src/redismodule.h" "${prefix}/include/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,10 @@ jobs:
         include:
           - elixir: "1.19"
             otp: "27"
+            redis: "7.2.14"
           - elixir: "1.20"
             otp: "29"
+            redis: "7.2.14"
 
     steps:
       - uses: actions/checkout@v7
@@ -30,11 +32,22 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
 
-      - name: Install Redis
+      - name: Cache Redis
+        id: redis-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/redis-server-wrapper/redis-${{ matrix.redis }}
+          key: redis-${{ runner.os }}-${{ runner.arch }}-${{ matrix.redis }}
+
+      - name: Build Redis ${{ matrix.redis }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y redis-server
-          redis-server --version
+          bash .github/scripts/build-redis.sh \
+            "${{ matrix.redis }}" \
+            "${HOME}/.cache/redis-server-wrapper/redis-${{ matrix.redis }}"
+          echo "${HOME}/.cache/redis-server-wrapper/redis-${{ matrix.redis }}/bin" >> "${GITHUB_PATH}"
+
+      - name: Report Redis version
+        run: redis-server --version
 
       - name: Restore deps cache
         uses: actions/cache@v6
@@ -80,6 +93,59 @@ jobs:
       - name: Run tests with coverage gate
         if: matrix.elixir == '1.20' && matrix.otp == '29'
         run: mix test --cover
+
+  redis-compatibility:
+    name: Redis ${{ matrix.redis }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        redis: ["7.2.14", "7.4.9", "8.2.6", "8.8.0"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.19"
+          otp-version: "27"
+
+      - name: Cache Redis
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/redis-server-wrapper/redis-${{ matrix.redis }}
+          key: redis-${{ runner.os }}-${{ runner.arch }}-${{ matrix.redis }}
+
+      - name: Build Redis ${{ matrix.redis }}
+        run: |
+          bash .github/scripts/build-redis.sh \
+            "${{ matrix.redis }}" \
+            "${HOME}/.cache/redis-server-wrapper/redis-${{ matrix.redis }}"
+          echo "${HOME}/.cache/redis-server-wrapper/redis-${{ matrix.redis }}/bin" >> "${GITHUB_PATH}"
+          echo "REDIS_PREFIX=${HOME}/.cache/redis-server-wrapper/redis-${{ matrix.redis }}" >> "${GITHUB_ENV}"
+
+      - name: Build version-matrix module
+        run: |
+          cc -fPIC -shared \
+            -I "${REDIS_PREFIX}/include" \
+            test/support/version_matrix_module.c \
+            -o "${RUNNER_TEMP}/version_matrix_module.so"
+          echo "REDIS_TEST_MODULE=${RUNNER_TEMP}/version_matrix_module.so" >> "${GITHUB_ENV}"
+
+      - name: Report Redis version
+        run: redis-server --version
+
+      - name: Restore deps cache
+        uses: actions/cache@v6
+        with:
+          path: deps
+          key: compat-deps-1.19-27-${{ hashFiles('mix.lock') }}
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run standalone, Cluster, Sentinel, and module tests
+        run: mix test
 
   docs:
     name: Docs

--- a/README.md
+++ b/README.md
@@ -41,6 +41,36 @@ sudo apt-get install redis-server
 redis-server --version
 ```
 
+### Supported Redis versions and distributions
+
+The supported Redis lines are 7.2, 7.4, 8.2, and the latest Redis 8.x release.
+CI runs the full standalone, Cluster, and Sentinel suite against a current patch
+release from each line, including a custom-module startup test. New patch
+releases within those lines are supported; older releases may work but are not
+part of the compatibility contract.
+
+Startup uses the core `redis-server` on PATH by default:
+
+```elixir
+# Redis Open Source / core (default)
+RedisServerWrapper.start_server(distribution: :core)
+
+# Redis 8 full distribution; modules are managed by Redis itself
+RedisServerWrapper.start_server(distribution: :full)
+
+# Legacy Redis Stack only; enables sibling-module discovery
+RedisServerWrapper.start_server(
+  distribution: :legacy_stack,
+  redis_server_bin: "/path/to/redis-stack/bin/redis-server"
+)
+```
+
+An explicit `:redis_server_bin` always wins. Legacy Stack selection can also use
+the `REDIS_LEGACY_STACK_SERVER_BIN` environment variable. The wrapper never
+silently switches distributions, and it only discovers sibling Stack modules
+when `distribution: :legacy_stack` is explicit. Caller-provided `:loadmodule`
+entries work with every distribution.
+
 ## Quick Start
 
 ### Single Server

--- a/lib/redis_server_wrapper.ex
+++ b/lib/redis_server_wrapper.ex
@@ -57,15 +57,16 @@ defmodule RedisServerWrapper do
   Checks if `redis-server` is available on PATH (or at the given path).
   """
   @spec available?(String.t()) :: boolean()
-  def available?(bin \\ "redis-server") do
+  def available?(bin \\ Server.default_server_bin()) do
     System.find_executable(bin) != nil
   end
 
   @doc """
-  Returns the version of redis-server on PATH, or `{:error, reason}`.
+  Returns the version of the same core redis-server binary selected by default
+  startup, or of an explicitly supplied binary.
   """
   @spec version(String.t()) :: {:ok, String.t()} | {:error, term()}
-  def version(bin \\ "redis-server") do
+  def version(bin \\ Server.default_server_bin()) do
     with path when not is_nil(path) <- System.find_executable(bin),
          {output, 0} <- System.cmd(path, ["--version"], stderr_to_stdout: true) do
       case Regex.run(~r/v=(\S+)/, output) do

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -30,6 +30,7 @@ defmodule RedisServerWrapper.Cluster do
     * `:password` - Redis password (default: nil)
     * `:redis_server_bin` - redis-server binary path
     * `:redis_cli_bin` - redis-cli binary path
+    * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
     * `:timeout` - startup timeout per node in ms (default: 10_000)
     * `:cluster_node_timeout` - cluster node timeout in ms (default: 5000)
     * `:loadmodule` - modules loaded into every cluster node; accepts paths or
@@ -128,10 +129,7 @@ defmodule RedisServerWrapper.Cluster do
       |> Config.control_host()
 
     password = Keyword.get(opts, :password)
-
-    redis_server_bin =
-      Keyword.get_lazy(opts, :redis_server_bin, &RedisServerWrapper.Server.default_server_bin/0)
-
+    distribution = Keyword.get(opts, :distribution, :core)
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, 10_000)
     cluster_node_timeout = Keyword.get(opts, :cluster_node_timeout, 5000)
@@ -139,24 +137,30 @@ defmodule RedisServerWrapper.Cluster do
     extra = Keyword.get(opts, :extra, [])
     managed = Keyword.get(opts, :managed, true)
 
-    settings = %{
-      masters: masters,
-      replicas_per_master: replicas,
-      base_port: base_port,
-      bind: bind,
-      control_host: control_host,
-      password: password,
-      redis_server_bin: redis_server_bin,
-      redis_cli_bin: redis_cli_bin,
-      timeout: timeout,
-      cluster_node_timeout: cluster_node_timeout,
-      loadmodule: loadmodule,
-      extra: extra,
-      managed: managed
-    }
-
-    case validate_options(settings) do
-      :ok -> start_validated_cluster(settings)
+    with :ok <- Server.validate_distribution(distribution),
+         redis_server_bin =
+           Keyword.get_lazy(opts, :redis_server_bin, fn ->
+             Server.default_server_bin(distribution)
+           end),
+         settings = %{
+           masters: masters,
+           replicas_per_master: replicas,
+           base_port: base_port,
+           bind: bind,
+           control_host: control_host,
+           password: password,
+           distribution: distribution,
+           redis_server_bin: redis_server_bin,
+           redis_cli_bin: redis_cli_bin,
+           timeout: timeout,
+           cluster_node_timeout: cluster_node_timeout,
+           loadmodule: loadmodule,
+           extra: extra,
+           managed: managed
+         },
+         :ok <- validate_options(settings) do
+      start_validated_cluster(settings)
+    else
       {:error, reason} -> {:stop, reason}
     end
   end
@@ -269,6 +273,7 @@ defmodule RedisServerWrapper.Cluster do
         :bind,
         :control_host,
         :password,
+        :distribution,
         :redis_server_bin,
         :redis_cli_bin,
         :timeout,
@@ -331,6 +336,7 @@ defmodule RedisServerWrapper.Cluster do
             bind: node_opts.bind,
             control_host: node_opts.control_host,
             password: node_opts.password,
+            distribution: node_opts.distribution,
             redis_server_bin: node_opts.redis_server_bin,
             redis_cli_bin: node_opts.redis_cli_bin,
             timeout: node_opts.timeout,

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -58,6 +58,7 @@ defmodule RedisServerWrapper.Manager do
     * `:persist` - enable persistence (default: false)
     * `:maxmemory` - memory limit (e.g., "256mb")
     * `:loadmodule` - modules to load; accepts paths or `{path, [args]}` tuples
+    * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
     * Plus any `RedisServerWrapper.Config` options via `:extra`
   """
   @spec start_basic(keyword()) :: {:ok, instance()} | {:error, term()}
@@ -75,6 +76,7 @@ defmodule RedisServerWrapper.Manager do
     persist = Keyword.get(opts, :persist, false)
     maxmemory = Keyword.get(opts, :maxmemory)
     loadmodule = Keyword.get(opts, :loadmodule, [])
+    distribution = Keyword.get(opts, :distribution, :core)
     extra = Keyword.get(opts, :extra, [])
 
     if Map.has_key?(state.instances, name) do
@@ -89,6 +91,7 @@ defmodule RedisServerWrapper.Manager do
           save: if(persist, do: :default, else: :disabled),
           appendonly: persist,
           managed: false,
+          distribution: distribution,
           loadmodule: loadmodule
         ]
         |> maybe_put(:maxmemory, maxmemory)
@@ -139,6 +142,7 @@ defmodule RedisServerWrapper.Manager do
     * `:bind` - bind address (default: "127.0.0.1")
     * `:control_host` - address used for client and cluster operations
     * `:loadmodule` - modules loaded into every cluster node
+    * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
   """
   @spec start_cluster(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_cluster(opts \\ []) do
@@ -155,6 +159,7 @@ defmodule RedisServerWrapper.Manager do
     bind = Keyword.get(opts, :bind, "127.0.0.1")
     control_host = Keyword.get(opts, :control_host)
     loadmodule = Keyword.get(opts, :loadmodule, [])
+    distribution = Keyword.get(opts, :distribution, :core)
 
     if Map.has_key?(state.instances, name) do
       {:error, {:instance_exists, name}}
@@ -167,6 +172,7 @@ defmodule RedisServerWrapper.Manager do
         control_host: control_host,
         password: password,
         managed: false,
+        distribution: distribution,
         loadmodule: loadmodule
       ]
 
@@ -223,6 +229,7 @@ defmodule RedisServerWrapper.Manager do
     * `:password` - Redis password (auto-generated if omitted)
     * `:bind` - bind address (default: "127.0.0.1")
     * `:loadmodule` - modules loaded into the master and every replica
+    * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
   """
   @spec start_sentinel(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_sentinel(opts \\ []) do
@@ -241,6 +248,7 @@ defmodule RedisServerWrapper.Manager do
     bind = Keyword.get(opts, :bind, "127.0.0.1")
     control_host = Keyword.get(opts, :control_host)
     loadmodule = Keyword.get(opts, :loadmodule, [])
+    distribution = Keyword.get(opts, :distribution, :core)
 
     if Map.has_key?(state.instances, name) do
       {:error, {:instance_exists, name}}
@@ -255,6 +263,7 @@ defmodule RedisServerWrapper.Manager do
         control_host: control_host,
         password: password,
         managed: false,
+        distribution: distribution,
         loadmodule: loadmodule
       ]
 

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -31,6 +31,7 @@ defmodule RedisServerWrapper.Sentinel do
     * `:password` - Redis password
     * `:redis_server_bin` - redis-server binary path
     * `:redis_cli_bin` - redis-cli binary path
+    * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
     * `:timeout` - startup timeout per node in ms (default: 10_000)
     * `:loadmodule` - modules loaded into the master and every replica; accepts
       paths or `{path, [args]}` tuples (default: `[]`). Sentinel processes do
@@ -139,39 +140,40 @@ defmodule RedisServerWrapper.Sentinel do
       |> Config.control_host()
 
     password = Keyword.get(opts, :password)
-
-    redis_server_bin =
-      Keyword.get_lazy(opts, :redis_server_bin, &RedisServerWrapper.Server.default_server_bin/0)
-
+    distribution = Keyword.get(opts, :distribution, :core)
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, 10_000)
     loadmodule = Keyword.get(opts, :loadmodule, [])
     managed = Keyword.get(opts, :managed, true)
 
-    node_opts = %{
-      bind: bind,
-      control_host: control_host,
-      password: password,
-      redis_server_bin: redis_server_bin,
-      redis_cli_bin: redis_cli_bin,
-      timeout: timeout,
-      loadmodule: loadmodule,
-      managed: managed
-    }
-
-    validation_settings = %{
-      master_port: master_port,
-      replicas: num_replicas,
-      replica_base_port: replica_base_port,
-      sentinels: num_sentinels,
-      sentinel_base_port: sentinel_base_port,
-      quorum: quorum,
-      down_after_ms: down_after_ms,
-      failover_timeout_ms: failover_timeout_ms,
-      timeout: timeout
-    }
-
-    with :ok <- validate_options(validation_settings),
+    with :ok <- Server.validate_distribution(distribution),
+         redis_server_bin =
+           Keyword.get_lazy(opts, :redis_server_bin, fn ->
+             Server.default_server_bin(distribution)
+           end),
+         node_opts = %{
+           bind: bind,
+           control_host: control_host,
+           password: password,
+           distribution: distribution,
+           redis_server_bin: redis_server_bin,
+           redis_cli_bin: redis_cli_bin,
+           timeout: timeout,
+           loadmodule: loadmodule,
+           managed: managed
+         },
+         validation_settings = %{
+           master_port: master_port,
+           replicas: num_replicas,
+           replica_base_port: replica_base_port,
+           sentinels: num_sentinels,
+           sentinel_base_port: sentinel_base_port,
+           quorum: quorum,
+           down_after_ms: down_after_ms,
+           failover_timeout_ms: failover_timeout_ms,
+           timeout: timeout
+         },
+         :ok <- validate_options(validation_settings),
          {:ok, master_pid} <- start_master(master_port, node_opts),
          {:ok, replica_pids} <-
            start_replicas(num_replicas, replica_base_port, master_port, node_opts),
@@ -339,6 +341,7 @@ defmodule RedisServerWrapper.Sentinel do
       bind: node_opts.bind,
       control_host: node_opts.control_host,
       password: node_opts.password,
+      distribution: node_opts.distribution,
       redis_server_bin: node_opts.redis_server_bin,
       redis_cli_bin: node_opts.redis_cli_bin,
       timeout: node_opts.timeout,
@@ -360,6 +363,7 @@ defmodule RedisServerWrapper.Sentinel do
           bind: node_opts.bind,
           control_host: node_opts.control_host,
           password: node_opts.password,
+          distribution: node_opts.distribution,
           masterauth: node_opts.password,
           replicaof: {node_opts.control_host, master_port},
           redis_server_bin: node_opts.redis_server_bin,

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -18,6 +18,9 @@ defmodule RedisServerWrapper.Server do
 
     * `:redis_server_bin` - path to redis-server binary (default: "redis-server")
     * `:redis_cli_bin` - path to redis-cli binary (default: "redis-cli")
+    * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`.
+      Only explicit `:legacy_stack` selection enables legacy Stack module
+      discovery; caller-provided `:loadmodule` entries always remain explicit.
     * `:name` - GenServer name registration
     * `:timeout` - startup timeout in ms (default: 10_000)
     * `:loadmodule` - Redis modules to load; accepts module paths or
@@ -46,6 +49,7 @@ defmodule RedisServerWrapper.Server do
   @compile {:no_warn_undefined, Forcola.Daemon}
 
   @default_timeout 10_000
+  @legacy_stack_server_env "REDIS_LEGACY_STACK_SERVER_BIN"
 
   defstruct [
     :config,
@@ -53,6 +57,7 @@ defmodule RedisServerWrapper.Server do
     :pid,
     :node_dir,
     :redis_server_bin,
+    :distribution,
     :port_ref,
     :daemon,
     managed: true,
@@ -60,6 +65,7 @@ defmodule RedisServerWrapper.Server do
   ]
 
   @type managed :: boolean() | :forcola
+  @type distribution :: :core | :full | :legacy_stack
 
   @type t :: %__MODULE__{
           config: Config.t(),
@@ -67,6 +73,7 @@ defmodule RedisServerWrapper.Server do
           pid: non_neg_integer() | nil,
           node_dir: String.t() | nil,
           redis_server_bin: String.t(),
+          distribution: distribution(),
           port_ref: port() | nil,
           daemon: pid() | nil,
           managed: managed(),
@@ -127,40 +134,26 @@ defmodule RedisServerWrapper.Server do
   def stop(server), do: GenServer.stop(server, :normal)
 
   @doc """
-  Returns the default redis-server binary path.
-  Prefers the actual redis-server binary from redis-stack (includes modules)
-  over the wrapper script, then falls back to plain redis-server.
+  Returns the default redis-server binary for a distribution.
 
-  We avoid the redis-stack-server bash wrapper because it overrides our
-  `dir` config with its own --dir flag, causing cluster config files to
-  end up in the wrong place. Instead, we use the real binary directly.
+  Core and Redis 8 Full use `redis-server` from PATH. Legacy Redis Stack is
+  opt-in and uses `REDIS_LEGACY_STACK_SERVER_BIN` when set, otherwise
+  `redis-stack-server`.
   """
-  @spec default_server_bin() :: String.t()
-  def default_server_bin do
-    # Prefer the actual binary inside the redis-stack cask (not the wrapper script)
-    stack_bin = find_stack_redis_server()
+  @spec default_server_bin(distribution()) :: String.t()
+  def default_server_bin(distribution \\ :core)
+  def default_server_bin(distribution) when distribution in [:core, :full], do: "redis-server"
 
-    cond do
-      stack_bin -> stack_bin
-      System.find_executable("redis-server") -> "redis-server"
-      true -> "redis-server"
-    end
-  end
+  def default_server_bin(:legacy_stack),
+    do: System.get_env(@legacy_stack_server_env) || "redis-stack-server"
 
-  # Find the real redis-server binary inside the redis-stack installation.
-  # The wrapper script at /opt/homebrew/bin/redis-stack-server just calls
-  # the real binary with --loadmodule flags. We want the real binary so
-  # we have full control over config (especially `dir`).
-  defp find_stack_redis_server do
-    paths = [
-      "/opt/homebrew/Caskroom/redis-stack-server/*/bin/redis-server",
-      "/usr/local/Caskroom/redis-stack-server/*/bin/redis-server"
-    ]
+  @doc false
+  @spec validate_distribution(term()) :: :ok | {:error, {:invalid_distribution, term()}}
+  def validate_distribution(distribution)
+      when distribution in [:core, :full, :legacy_stack],
+      do: :ok
 
-    paths
-    |> Enum.flat_map(&Path.wildcard/1)
-    |> List.first()
-  end
+  def validate_distribution(other), do: {:error, {:invalid_distribution, other}}
 
   # -------------------------------------------------------------------
   # GenServer callbacks
@@ -170,21 +163,38 @@ defmodule RedisServerWrapper.Server do
   def init(opts) do
     Process.flag(:trap_exit, true)
 
-    redis_server_bin = Keyword.get_lazy(opts, :redis_server_bin, &default_server_bin/0)
+    distribution = Keyword.get(opts, :distribution, :core)
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     managed = Keyword.get(opts, :managed, true)
 
     # Validate binaries and the managed backend selection
-    with :ok <- validate_managed(managed),
+    with :ok <- validate_distribution(distribution),
+         redis_server_bin =
+           Keyword.get_lazy(opts, :redis_server_bin, fn -> default_server_bin(distribution) end),
+         :ok <- validate_managed(managed),
          :ok <- check_binary(redis_server_bin),
          :ok <- check_binary(redis_cli_bin) do
       config_opts =
-        Keyword.drop(opts, [:redis_server_bin, :redis_cli_bin, :name, :timeout, :managed])
+        Keyword.drop(opts, [
+          :redis_server_bin,
+          :redis_cli_bin,
+          :distribution,
+          :name,
+          :timeout,
+          :managed
+        ])
 
       config = Config.new(config_opts)
 
-      case start_redis_server(config, redis_server_bin, redis_cli_bin, timeout, managed) do
+      case start_redis_server(
+             config,
+             redis_server_bin,
+             redis_cli_bin,
+             timeout,
+             managed,
+             distribution
+           ) do
         {:ok, state} ->
           {:ok, state}
 
@@ -217,6 +227,7 @@ defmodule RedisServerWrapper.Server do
       password: state.config.password,
       pid: state.pid,
       node_dir: state.node_dir,
+      distribution: state.distribution,
       detached: state.detached,
       managed: state.managed
     }
@@ -326,22 +337,40 @@ defmodule RedisServerWrapper.Server do
   # Internal helpers
   # -------------------------------------------------------------------
 
-  defp start_redis_server(config, redis_server_bin, redis_cli_bin, timeout, managed) do
+  defp start_redis_server(
+         config,
+         redis_server_bin,
+         redis_cli_bin,
+         timeout,
+         managed,
+         distribution
+       ) do
     case managed do
-      :forcola -> start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout)
-      true -> start_managed(config, redis_server_bin, redis_cli_bin, timeout)
-      false -> start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout)
+      :forcola ->
+        start_managed_forcola(
+          config,
+          redis_server_bin,
+          redis_cli_bin,
+          timeout,
+          distribution
+        )
+
+      true ->
+        start_managed(config, redis_server_bin, redis_cli_bin, timeout, distribution)
+
+      false ->
+        start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout, distribution)
     end
   end
 
   # Port-based: redis-server runs in the foreground, tied to the BEAM.
-  defp start_managed(config, redis_server_bin, redis_cli_bin, timeout) do
+  defp start_managed(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
     with :ok <- check_port_available(Config.control_host(config), config.port) do
-      do_start_managed(config, redis_server_bin, redis_cli_bin, timeout)
+      do_start_managed(config, redis_server_bin, redis_cli_bin, timeout, distribution)
     end
   end
 
-  defp do_start_managed(config, redis_server_bin, redis_cli_bin, timeout) do
+  defp do_start_managed(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
     node_dir = make_node_dir(config.port)
 
     config = %{
@@ -358,7 +387,7 @@ defmodule RedisServerWrapper.Server do
     server_bin_path = System.find_executable(redis_server_bin)
 
     # If using the redis-stack binary, load the Stack modules
-    module_args = detect_stack_modules(server_bin_path)
+    module_args = distribution_module_args(distribution, server_bin_path)
 
     port_ref =
       Port.open({:spawn_executable, server_bin_path}, [
@@ -390,6 +419,7 @@ defmodule RedisServerWrapper.Server do
           pid: os_pid,
           node_dir: node_dir,
           redis_server_bin: redis_server_bin,
+          distribution: distribution,
           port_ref: port_ref,
           managed: true
         }
@@ -411,17 +441,35 @@ defmodule RedisServerWrapper.Server do
   # guarantees the OS process group is killed and confirmed dead on owner death
   # or supervisor shutdown, including the :brutal_kill and hard-BEAM-death paths
   # where terminate/2 never runs.
-  defp start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout) do
+  defp start_managed_forcola(
+         config,
+         redis_server_bin,
+         redis_cli_bin,
+         timeout,
+         distribution
+       ) do
     if forcola_available?() do
       with :ok <- check_port_available(Config.control_host(config), config.port) do
-        do_start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout)
+        do_start_managed_forcola(
+          config,
+          redis_server_bin,
+          redis_cli_bin,
+          timeout,
+          distribution
+        )
       end
     else
       {:error, :forcola_not_available}
     end
   end
 
-  defp do_start_managed_forcola(config, redis_server_bin, redis_cli_bin, timeout) do
+  defp do_start_managed_forcola(
+         config,
+         redis_server_bin,
+         redis_cli_bin,
+         timeout,
+         distribution
+       ) do
     node_dir = make_node_dir(config.port)
 
     config = %{
@@ -438,7 +486,7 @@ defmodule RedisServerWrapper.Server do
     server_bin_path = System.find_executable(redis_server_bin)
 
     # If using the redis-stack binary, load the Stack modules
-    module_args = detect_stack_modules(server_bin_path)
+    module_args = distribution_module_args(distribution, server_bin_path)
 
     cli =
       Cli.new(
@@ -465,6 +513,7 @@ defmodule RedisServerWrapper.Server do
           pid: read_pidfile(Path.join(node_dir, "redis.pid")),
           node_dir: node_dir,
           redis_server_bin: redis_server_bin,
+          distribution: distribution,
           daemon: daemon,
           managed: :forcola
         }
@@ -494,13 +543,13 @@ defmodule RedisServerWrapper.Server do
   # whose pid is in the pidfile" heuristic would silently murder live,
   # wanted instances. If the port is held, check_port_available returns
   # {:error, {:port_in_use, ...}} and the caller decides what to do.
-  defp start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout) do
+  defp start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
     with :ok <- check_port_available(Config.control_host(config), config.port) do
-      do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout)
+      do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout, distribution)
     end
   end
 
-  defp do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout) do
+  defp do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
     node_dir = make_node_dir(config.port)
     pidfile_path = Path.join(node_dir, "redis.pid")
 
@@ -518,7 +567,7 @@ defmodule RedisServerWrapper.Server do
     server_bin_path = System.find_executable(redis_server_bin) || redis_server_bin
 
     # If using the redis-stack binary, load the Stack modules
-    module_args = detect_stack_modules(server_bin_path)
+    module_args = distribution_module_args(distribution, server_bin_path)
 
     case System.cmd(server_bin_path, [conf_path | module_args], stderr_to_stdout: true) do
       {_output, 0} ->
@@ -540,6 +589,7 @@ defmodule RedisServerWrapper.Server do
               pid: pid,
               node_dir: node_dir,
               redis_server_bin: redis_server_bin,
+              distribution: distribution,
               managed: false
             }
 
@@ -690,10 +740,10 @@ defmodule RedisServerWrapper.Server do
 
   defp warn_if_signal_unavailable(_result, _pid), do: :ok
 
-  # Detect Redis Stack modules (RedisJSON, RediSearch, etc.) if we're using
-  # the redis-stack binary. Returns command-line args like
+  # Detect Redis Stack modules (RedisJSON, RediSearch, etc.) only when the
+  # legacy Stack distribution is explicitly selected. Returns command-line args like
   # ["--loadmodule", "/path/to/rejson.so", "--loadmodule", "/path/to/redisearch.so", ...]
-  defp detect_stack_modules(server_bin_path) do
+  defp distribution_module_args(:legacy_stack, server_bin_path) do
     # Check if this binary lives inside a redis-stack installation
     bin_dir = Path.dirname(server_bin_path)
     lib_dir = Path.join(Path.dirname(bin_dir), "lib")
@@ -714,6 +764,8 @@ defmodule RedisServerWrapper.Server do
       []
     end
   end
+
+  defp distribution_module_args(_distribution, _server_bin_path), do: []
 
   defp module_args(lib_dir, {mod_file, args}) do
     mod_path = Path.join(lib_dir, mod_file)

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -212,6 +212,7 @@ defmodule RedisServerWrapperTest do
       assert info.port == 6400
       assert info.pid != nil
       assert info.detached == false
+      assert info.distribution == :core
 
       assert {:ok, "OK"} = Server.run(server, ["SET", "mykey", "myvalue"])
       assert {:ok, "myvalue"} = Server.run(server, ["GET", "mykey"])
@@ -251,6 +252,24 @@ defmodule RedisServerWrapperTest do
         assert Server.cli(server).host == "127.0.0.1"
       after
         Server.stop(server)
+      end
+    end
+
+    test "loads the version-matrix module when the compatibility job provides it" do
+      case System.get_env("REDIS_TEST_MODULE") do
+        nil ->
+          :ok
+
+        module_path ->
+          {:ok, server} = Server.start_link(port: 6406, loadmodule: [module_path])
+
+          try do
+            assert Server.ping(server)
+            assert {:ok, modules} = Server.run(server, ["MODULE", "LIST"])
+            assert modules =~ "wrapper_version_matrix"
+          after
+            Server.stop(server)
+          end
       end
     end
 

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -175,6 +175,23 @@ defmodule RedisServerWrapperUnitTest do
   end
 
   test "top-level availability and version helpers cover every result shape", context do
+    assert Server.default_server_bin() == "redis-server"
+    assert Server.default_server_bin(:core) == "redis-server"
+    assert Server.default_server_bin(:full) == "redis-server"
+
+    original_legacy_bin = System.get_env("REDIS_LEGACY_STACK_SERVER_BIN")
+    System.put_env("REDIS_LEGACY_STACK_SERVER_BIN", context.version_bin)
+
+    on_exit(fn ->
+      if original_legacy_bin do
+        System.put_env("REDIS_LEGACY_STACK_SERVER_BIN", original_legacy_bin)
+      else
+        System.delete_env("REDIS_LEGACY_STACK_SERVER_BIN")
+      end
+    end)
+
+    assert Server.default_server_bin(:legacy_stack) == context.version_bin
+
     assert RedisServerWrapper.available?(context.version_bin)
     refute RedisServerWrapper.available?("definitely-missing-redis-binary")
 
@@ -194,11 +211,44 @@ defmodule RedisServerWrapperUnitTest do
     assert {:error, {:binary_not_found, "missing-redis-cli"}} =
              Server.start(redis_cli_bin: "missing-redis-cli")
 
+    assert {:error, {:invalid_distribution, :unknown}} =
+             Server.start(distribution: :unknown)
+
     assert {:error, {:server_start_failed, 6440, _status, _output}} =
              Server.start(port: 6440, managed: false, redis_server_bin: "false")
 
     assert {:error, {:server_start_timeout, 6441}} =
              Server.start(port: 6441, managed: true, redis_server_bin: "false", timeout: 20)
+  end
+
+  test "legacy Stack module discovery is explicit", %{fixture_dir: fixture_dir} do
+    prefix = Path.join(fixture_dir, "legacy-stack")
+    bin_dir = Path.join(prefix, "bin")
+    lib_dir = Path.join(prefix, "lib")
+    File.mkdir_p!(bin_dir)
+    File.mkdir_p!(lib_dir)
+
+    redis_server = Path.join(bin_dir, "redis-server")
+    File.ln_s!(System.find_executable("redis-server"), redis_server)
+    File.write!(Path.join(lib_dir, "rediscompat.so"), "not a module")
+
+    {:ok, core_server} =
+      Server.start_link(
+        port: 6492,
+        redis_server_bin: redis_server,
+        distribution: :core
+      )
+
+    assert Server.ping(core_server)
+    assert Server.stop(core_server) == :ok
+
+    assert {:error, {:server_start_timeout, 6493}} =
+             Server.start(
+               port: 6493,
+               redis_server_bin: redis_server,
+               distribution: :legacy_stack,
+               timeout: 100
+             )
   end
 
   test "OS process helpers normalize executable results", %{fixture_dir: fixture_dir} do
@@ -298,6 +348,9 @@ defmodule RedisServerWrapperUnitTest do
   end
 
   test "cluster validates counts, ports, and timeouts before startup" do
+    assert {:error, {:invalid_distribution, :unknown}} =
+             Cluster.start(distribution: :unknown)
+
     assert {:error, {:invalid_option, :masters, 0}} = Cluster.start(masters: 0)
 
     assert {:error, {:invalid_option, :replicas_per_master, -1}} =
@@ -318,6 +371,9 @@ defmodule RedisServerWrapperUnitTest do
   end
 
   test "sentinel validates counts, quorum, ports, and timeouts before startup" do
+    assert {:error, {:invalid_distribution, :unknown}} =
+             Sentinel.start(distribution: :unknown)
+
     assert {:error, {:invalid_option, :replicas, -1}} = Sentinel.start(replicas: -1)
     assert {:error, {:invalid_option, :sentinels, 0}} = Sentinel.start(sentinels: 0)
     assert {:error, {:invalid_quorum, 4, 3}} = Sentinel.start(quorum: 4)

--- a/test/support/version_matrix_module.c
+++ b/test/support/version_matrix_module.c
@@ -1,0 +1,13 @@
+#include "redismodule.h"
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    REDISMODULE_NOT_USED(argv);
+    REDISMODULE_NOT_USED(argc);
+
+    if (RedisModule_Init(ctx, "wrapper_version_matrix", 1, REDISMODULE_APIVER_1) ==
+        REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    return REDISMODULE_OK;
+}


### PR DESCRIPTION
Closes #56

## Summary

- define Redis 7.2, 7.4, 8.2, and latest 8.x as the supported release lines
- build pinned Redis 7.2.14, 7.4.9, 8.2.6, and 8.8.0 binaries in a dedicated compatibility matrix
- exercise standalone, Cluster, Sentinel, and a compiled custom module on every supported line
- make distribution selection explicit with `:core`, `:full`, and `:legacy_stack`
- default normal startup and the version helper to the same `redis-server` binary on PATH
- remove silent Homebrew Redis Stack discovery; legacy Stack selection is explicit and supports `REDIS_LEGACY_STACK_SERVER_BIN`
- propagate distribution selection through Server, Cluster, Sentinel, and Manager
- document the version/distribution compatibility contract

## Local validation

- `mix test` — 80 passed
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`
- workflow YAML parse and build-script shell syntax checks