### PR TITLE
Support TLS, Unix sockets, and ACL auth end to end

### DIFF
--- a/.github/scripts/build-redis.sh
+++ b/.github/scripts/build-redis.sh
@@ -3,8 +3,13 @@ set -euo pipefail
 
 version="$1"
 prefix="$2"
+build_flavor="tls-v1"
+build_flavor_file="${prefix}/.build-flavor"
 
-if [[ -x "${prefix}/bin/redis-server" && -x "${prefix}/bin/redis-cli" ]]; then
+if [[ -x "${prefix}/bin/redis-server" &&
+      -x "${prefix}/bin/redis-cli" &&
+      -f "${build_flavor_file}" &&
+      "$(cat "${build_flavor_file}")" == "${build_flavor}" ]]; then
   exit 0
 fi
 
@@ -16,9 +21,10 @@ curl --fail --location --silent --show-error \
   --output "${work_dir}/redis.tar.gz"
 
 tar -xzf "${work_dir}/redis.tar.gz" --directory "${work_dir}"
-make -C "${work_dir}/redis-${version}" -j"$(nproc)"
+make -C "${work_dir}/redis-${version}" BUILD_TLS=yes -j"$(nproc)"
 
 mkdir -p "${prefix}/bin" "${prefix}/include"
 cp "${work_dir}/redis-${version}/src/redis-server" "${prefix}/bin/"
 cp "${work_dir}/redis-${version}/src/redis-cli" "${prefix}/bin/"
 cp "${work_dir}/redis-${version}/src/redismodule.h" "${prefix}/include/"
+printf '%s\n' "${build_flavor}" > "${build_flavor_file}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/redis-server-wrapper/redis-${{ matrix.redis }}
-          key: redis-${{ runner.os }}-${{ runner.arch }}-${{ matrix.redis }}
+          key: redis-tls-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.redis }}
 
       - name: Build Redis ${{ matrix.redis }}
         run: |
@@ -114,7 +114,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cache/redis-server-wrapper/redis-${{ matrix.redis }}
-          key: redis-${{ runner.os }}-${{ runner.arch }}-${{ matrix.redis }}
+          key: redis-tls-v1-${{ runner.os }}-${{ runner.arch }}-${{ matrix.redis }}
 
       - name: Build Redis ${{ matrix.redis }}
         run: |

--- a/README.md
+++ b/README.md
@@ -259,6 +259,73 @@ RedisServerWrapper.start_server(
 )
 ```
 
+### TCP, TLS, Unix sockets, and ACL authentication
+
+Lifecycle operations use a shared `RedisServerWrapper.Connection`, so startup
+readiness, commands, health checks, shutdown, Cluster, Sentinel, and Manager
+all retain the same endpoint and credentials.
+
+Set `username` with `password` to configure and use a named ACL user. Without a
+username, `password` retains its password-only `requirepass` behavior:
+
+```elixir
+RedisServerWrapper.start_server(
+  port: 6400,
+  username: "demo-app",
+  password: "secret"
+)
+```
+
+Disable TCP with `port: 0` for a Unix-only server:
+
+```elixir
+RedisServerWrapper.start_server(
+  port: 0,
+  unixsocket: "/tmp/demo-redis.sock",
+  unixsocketperm: "700"
+)
+```
+
+For a TLS-only server, set `port: 0`, a `tls_port`, and the server identity.
+The CA file or directory is also used by `redis-cli` for verification:
+
+```elixir
+RedisServerWrapper.start_server(
+  port: 0,
+  tls_port: 6400,
+  tls_cert_file: "/certs/server.crt",
+  tls_key_file: "/certs/server.key",
+  tls_ca_cert_file: "/certs/ca.crt",
+  tls_auth_clients: "no",
+  tls_server_name: "redis.demo.test"
+)
+```
+
+Use `tls_ca_cert_dir` instead of `tls_ca_cert_file` for a CA directory.
+Mutual-TLS clients can set `tls_client_cert_file` and
+`tls_client_key_file`. `tls_insecure: true` explicitly disables redis-cli
+certificate verification and is intended only for controlled tests.
+
+Cluster and Sentinel use TLS-only nodes when `tls: true`; pass the same
+certificate options:
+
+```elixir
+RedisServerWrapper.start_cluster(
+  masters: 3,
+  base_port: 7100,
+  tls: true,
+  tls_cert_file: "/certs/server.crt",
+  tls_key_file: "/certs/server.key",
+  tls_ca_cert_file: "/certs/ca.crt",
+  tls_auth_clients: "no"
+)
+```
+
+The wrapper enables `tls-cluster` or `tls-replication` as required. Sentinel
+also configures `sentinel auth-user`/`auth-pass` for named ACL credentials.
+Unix sockets are a standalone-server transport; Cluster and Sentinel reject
+them immediately because their nodes must communicate over network ports.
+
 ### Chaos / Fault Injection
 
 The `Chaos` module provides fault injection primitives for testing resilience:

--- a/lib/redis_server_wrapper/cli.ex
+++ b/lib/redis_server_wrapper/cli.ex
@@ -3,19 +3,14 @@ defmodule RedisServerWrapper.Cli do
   Wrapper around the `redis-cli` binary for running commands against Redis instances.
   """
 
+  alias RedisServerWrapper.Connection
+
   @type t :: %__MODULE__{
           bin: String.t(),
-          host: String.t(),
-          port: non_neg_integer(),
-          password: String.t() | nil,
-          tls: boolean()
+          connection: Connection.t()
         }
 
-  defstruct bin: "redis-cli",
-            host: "127.0.0.1",
-            port: 6379,
-            password: nil,
-            tls: false
+  defstruct bin: "redis-cli", connection: %Connection{}
 
   @doc """
   Creates a new Cli struct.
@@ -24,7 +19,24 @@ defmodule RedisServerWrapper.Cli do
   """
   @spec new(keyword()) :: t()
   def new(opts \\ []) do
-    struct!(__MODULE__, opts)
+    {bin, opts} = Keyword.pop(opts, :bin, "redis-cli")
+
+    connection =
+      case Keyword.pop(opts, :connection) do
+        {%Connection{} = connection, []} ->
+          connection
+
+        {nil, connection_opts} ->
+          connection_opts
+          |> normalize_legacy_options()
+          |> Connection.new()
+
+        {%Connection{}, remaining} ->
+          raise ArgumentError,
+                ":connection cannot be combined with connection options: #{inspect(remaining)}"
+      end
+
+    %__MODULE__{bin: bin, connection: connection}
   end
 
   @doc """
@@ -67,8 +79,10 @@ defmodule RedisServerWrapper.Cli do
   """
   @spec shutdown(t()) :: :ok
   def shutdown(%__MODULE__{} = cli) do
-    # Fire and forget - the connection will be closed by the server
-    spawn(fn -> run(cli, ["SHUTDOWN", "NOSAVE"]) end)
+    # redis-cli tolerates the server closing the connection as part of shutdown.
+    # Wait for the attempt to finish so a delayed command cannot hit a later
+    # process that reuses the same endpoint.
+    _result = run(cli, ["SHUTDOWN", "NOSAVE"])
     :ok
   end
 
@@ -136,7 +150,8 @@ defmodule RedisServerWrapper.Cli do
           {:ok, String.t()} | {:error, String.t()}
   def cluster_create(%__MODULE__{} = cli, node_addrs, replicas_per_master \\ 0) do
     args =
-      ["--cluster", "create"] ++
+      Connection.cli_args(cli.connection, include_endpoint: false) ++
+        ["--cluster", "create"] ++
         node_addrs ++
         ["--cluster-replicas", to_string(replicas_per_master), "--cluster-yes"]
 
@@ -170,8 +185,7 @@ defmodule RedisServerWrapper.Cli do
 
   # Build base connection arguments for redis-cli
   defp base_args(%__MODULE__{} = cli) do
-    ["-h", cli.host, "-p", to_string(cli.port)]
-    |> maybe_append(cli.tls, fn _ -> ["--tls"] end)
+    Connection.cli_args(cli.connection)
   end
 
   defp run_command(cli, args) do
@@ -179,16 +193,25 @@ defmodule RedisServerWrapper.Cli do
       cli.bin,
       args,
       stderr_to_stdout: true,
-      env: auth_env(cli)
+      env: Connection.cli_env(cli.connection)
     )
   end
 
-  defp auth_env(%__MODULE__{password: nil}), do: []
-  defp auth_env(%__MODULE__{password: password}), do: [{"REDISCLI_AUTH", password}]
+  defp normalize_legacy_options(opts) do
+    tls = Keyword.get(opts, :tls, false)
+    socket = Keyword.get(opts, :socket)
 
-  defp maybe_append(args, nil, _fun), do: args
-  defp maybe_append(args, false, _fun), do: args
-  defp maybe_append(args, value, fun), do: args ++ fun.(value)
+    transport =
+      cond do
+        socket -> :unix
+        tls -> :tls
+        true -> Keyword.get(opts, :transport, :tcp)
+      end
+
+    opts
+    |> Keyword.delete(:tls)
+    |> Keyword.put(:transport, transport)
+  end
 
   # Parse "key:value\r\n" format (CLUSTER INFO, INFO)
   defp parse_info(output) do

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -28,6 +28,13 @@ defmodule RedisServerWrapper.Cluster do
     * `:control_host` - address used by redis-cli and cluster announcements
       (default: first bind address)
     * `:password` - Redis password (default: nil)
+    * `:username` - optional ACL username paired with `:password`
+    * `:tls` - use TLS-only cluster node connections (default: false)
+    * `:tls_cert_file`, `:tls_key_file` - server certificate and private key
+    * `:tls_ca_cert_file` or `:tls_ca_cert_dir` - trusted CA for Redis and redis-cli
+    * `:tls_client_cert_file`, `:tls_client_key_file` - optional redis-cli client identity
+    * `:tls_server_name` - optional redis-cli SNI name
+    * `:tls_insecure` - explicitly disable redis-cli certificate verification
     * `:redis_server_bin` - redis-server binary path
     * `:redis_cli_bin` - redis-cli binary path
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
@@ -43,7 +50,7 @@ defmodule RedisServerWrapper.Cluster do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Config, Server}
+  alias RedisServerWrapper.{Cli, Config, Connection, Server}
 
   require Logger
 
@@ -53,6 +60,8 @@ defmodule RedisServerWrapper.Cluster do
     :base_port,
     :bind,
     :control_host,
+    :connection,
+    :username,
     :password,
     :redis_cli_bin,
     node_pids: [],
@@ -129,6 +138,7 @@ defmodule RedisServerWrapper.Cluster do
       |> Config.control_host()
 
     password = Keyword.get(opts, :password)
+    username = Keyword.get(opts, :username)
     distribution = Keyword.get(opts, :distribution, :core)
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, 10_000)
@@ -137,7 +147,10 @@ defmodule RedisServerWrapper.Cluster do
     extra = Keyword.get(opts, :extra, [])
     managed = Keyword.get(opts, :managed, true)
 
-    with :ok <- Server.validate_distribution(distribution),
+    with :ok <- valid_port(:base_port, base_port),
+         :ok <- reject_unix_transport(opts),
+         {:ok, connection} <- build_connection(opts, control_host, base_port),
+         :ok <- Server.validate_distribution(distribution),
          redis_server_bin =
            Keyword.get_lazy(opts, :redis_server_bin, fn ->
              Server.default_server_bin(distribution)
@@ -148,7 +161,19 @@ defmodule RedisServerWrapper.Cluster do
            base_port: base_port,
            bind: bind,
            control_host: control_host,
+           connection: connection,
+           username: username,
            password: password,
+           tls: connection.transport == :tls,
+           tls_cert_file: Keyword.get(opts, :tls_cert_file),
+           tls_key_file: Keyword.get(opts, :tls_key_file),
+           tls_ca_cert_file: Keyword.get(opts, :tls_ca_cert_file),
+           tls_ca_cert_dir: Keyword.get(opts, :tls_ca_cert_dir),
+           tls_auth_clients: Keyword.get(opts, :tls_auth_clients),
+           tls_client_cert_file: Keyword.get(opts, :tls_client_cert_file),
+           tls_client_key_file: Keyword.get(opts, :tls_client_key_file),
+           tls_server_name: Keyword.get(opts, :tls_server_name),
+           tls_insecure: Keyword.get(opts, :tls_insecure, false),
            distribution: distribution,
            redis_server_bin: redis_server_bin,
            redis_cli_bin: redis_cli_bin,
@@ -158,6 +183,7 @@ defmodule RedisServerWrapper.Cluster do
            extra: extra,
            managed: managed
          },
+         :ok <- validate_server_connection_config(settings),
          :ok <- validate_options(settings) do
       start_validated_cluster(settings)
     else
@@ -173,8 +199,8 @@ defmodule RedisServerWrapper.Cluster do
   def handle_call(:node_addrs, _from, state) do
     addrs =
       Enum.map(state.node_pids, fn pid ->
-        info = Server.info(pid)
-        format_addr(info.host, info.port)
+        connection = Server.info(pid).connection
+        format_addr(connection.host, connection.port)
       end)
 
     {:reply, addrs, state}
@@ -212,11 +238,12 @@ defmodule RedisServerWrapper.Cluster do
       base_port: state.base_port,
       bind: state.bind,
       control_host: state.control_host,
+      connection: state.connection,
       total_nodes: length(state.node_pids),
       node_addrs:
         Enum.map(state.node_pids, fn pid ->
-          node_info = Server.info(pid)
-          format_addr(node_info.host, node_info.port)
+          connection = Server.info(pid).connection
+          format_addr(connection.host, connection.port)
         end)
     }
 
@@ -272,7 +299,19 @@ defmodule RedisServerWrapper.Cluster do
       Map.take(settings, [
         :bind,
         :control_host,
+        :connection,
+        :username,
         :password,
+        :tls,
+        :tls_cert_file,
+        :tls_key_file,
+        :tls_ca_cert_file,
+        :tls_ca_cert_dir,
+        :tls_auth_clients,
+        :tls_client_cert_file,
+        :tls_client_key_file,
+        :tls_server_name,
+        :tls_insecure,
         :distribution,
         :redis_server_bin,
         :redis_cli_bin,
@@ -292,13 +331,7 @@ defmodule RedisServerWrapper.Cluster do
   end
 
   defp form_cluster(node_pids, ports, settings) do
-    seed_cli =
-      Cli.new(
-        bin: settings.redis_cli_bin,
-        host: settings.control_host,
-        port: settings.base_port,
-        password: settings.password
-      )
+    seed_cli = node_pids |> List.first() |> Server.cli()
 
     node_addr_list = Enum.map(ports, &format_addr(settings.control_host, &1))
 
@@ -313,6 +346,8 @@ defmodule RedisServerWrapper.Cluster do
           base_port: settings.base_port,
           bind: settings.bind,
           control_host: settings.control_host,
+          connection: settings.connection,
+          username: settings.username,
           password: settings.password,
           redis_cli_bin: settings.redis_cli_bin,
           node_pids: node_pids
@@ -331,22 +366,22 @@ defmodule RedisServerWrapper.Cluster do
     results =
       Enum.reduce_while(ports, {:ok, []}, fn port, {:ok, acc} ->
         opts =
-          [
-            port: port,
-            bind: node_opts.bind,
-            control_host: node_opts.control_host,
-            password: node_opts.password,
-            distribution: node_opts.distribution,
-            redis_server_bin: node_opts.redis_server_bin,
-            redis_cli_bin: node_opts.redis_cli_bin,
-            timeout: node_opts.timeout,
-            managed: node_opts.managed,
-            cluster_enabled: true,
-            cluster_config_file: "nodes-#{port}.conf",
-            cluster_node_timeout: node_opts.cluster_node_timeout,
-            loadmodule: node_opts.loadmodule,
-            save: :disabled
-          ] ++ extra_to_opts(node_opts.extra)
+          connection_server_opts(node_opts, port) ++
+            [
+              bind: node_opts.bind,
+              control_host: node_opts.control_host,
+              distribution: node_opts.distribution,
+              redis_server_bin: node_opts.redis_server_bin,
+              redis_cli_bin: node_opts.redis_cli_bin,
+              timeout: node_opts.timeout,
+              managed: node_opts.managed,
+              cluster_enabled: true,
+              cluster_config_file: "nodes-#{port}.conf",
+              cluster_node_timeout: node_opts.cluster_node_timeout,
+              cluster_announce_port: port,
+              loadmodule: node_opts.loadmodule,
+              save: :disabled
+            ] ++ extra_to_opts(node_opts.extra)
 
         case Server.start_link(opts) do
           {:ok, pid} ->
@@ -365,10 +400,78 @@ defmodule RedisServerWrapper.Cluster do
   defp seed_cli(state) do
     Cli.new(
       bin: state.redis_cli_bin,
-      host: state.control_host,
-      port: state.base_port,
-      password: state.password
+      connection: state.connection
     )
+  end
+
+  defp connection_server_opts(%{tls: false} = opts, port) do
+    [
+      port: port,
+      username: opts.username,
+      password: opts.password
+    ]
+  end
+
+  defp connection_server_opts(%{tls: true} = opts, port) do
+    [
+      port: 0,
+      tls_port: port,
+      username: opts.username,
+      password: opts.password,
+      tls_cert_file: opts.tls_cert_file,
+      tls_key_file: opts.tls_key_file,
+      tls_ca_cert_file: opts.tls_ca_cert_file,
+      tls_ca_cert_dir: opts.tls_ca_cert_dir,
+      tls_auth_clients: opts.tls_auth_clients,
+      tls_client_cert_file: opts.tls_client_cert_file,
+      tls_client_key_file: opts.tls_client_key_file,
+      tls_server_name: opts.tls_server_name,
+      tls_insecure: opts.tls_insecure,
+      tls_cluster: true
+    ]
+  end
+
+  defp build_connection(opts, host, port) do
+    transport = if Keyword.get(opts, :tls, false), do: :tls, else: :tcp
+
+    connection_opts = [
+      transport: transport,
+      host: host,
+      port: port,
+      username: Keyword.get(opts, :username),
+      password: Keyword.get(opts, :password),
+      tls_ca_cert_file: Keyword.get(opts, :tls_ca_cert_file),
+      tls_ca_cert_dir: Keyword.get(opts, :tls_ca_cert_dir),
+      tls_client_cert_file: Keyword.get(opts, :tls_client_cert_file),
+      tls_client_key_file: Keyword.get(opts, :tls_client_key_file),
+      tls_server_name: Keyword.get(opts, :tls_server_name),
+      tls_insecure: Keyword.get(opts, :tls_insecure, false)
+    ]
+
+    {:ok, Connection.new(connection_opts)}
+  rescue
+    error in ArgumentError -> {:error, {:invalid_connection, Exception.message(error)}}
+  end
+
+  defp reject_unix_transport(opts) do
+    if Keyword.get(opts, :unixsocket) || Keyword.get(opts, :transport) == :unix do
+      {:error, {:unsupported_transport, :cluster, :unix}}
+    else
+      :ok
+    end
+  end
+
+  defp validate_server_connection_config(settings) do
+    _config =
+      Config.new(
+        connection_server_opts(settings, settings.base_port) ++
+          [bind: settings.bind, control_host: settings.control_host]
+      )
+
+    :ok
+  rescue
+    error in ArgumentError ->
+      {:error, {:invalid_connection_config, Exception.message(error)}}
   end
 
   defp extra_to_opts([]), do: []

--- a/lib/redis_server_wrapper/config.ex
+++ b/lib/redis_server_wrapper/config.ex
@@ -22,6 +22,8 @@ defmodule RedisServerWrapper.Config do
   @type bind_addresses :: String.t() | [String.t()]
   @type extra_spec :: {String.t(), String.t() | [String.t()]}
 
+  alias RedisServerWrapper.Connection
+
   # These validators intentionally defend the runtime struct boundary against
   # values outside the public typespec.
   @dialyzer {:nowarn_function, validate_save!: 1}
@@ -32,6 +34,7 @@ defmodule RedisServerWrapper.Config do
           port: non_neg_integer(),
           bind: bind_addresses(),
           control_host: String.t() | nil,
+          username: String.t() | nil,
           password: String.t() | nil,
           loglevel: log_level(),
           logfile: String.t() | nil,
@@ -56,9 +59,17 @@ defmodule RedisServerWrapper.Config do
           tls_cert_file: String.t() | nil,
           tls_key_file: String.t() | nil,
           tls_ca_cert_file: String.t() | nil,
+          tls_ca_cert_dir: String.t() | nil,
           tls_auth_clients: String.t() | nil,
+          tls_client_cert_file: String.t() | nil,
+          tls_client_key_file: String.t() | nil,
+          tls_server_name: String.t() | nil,
+          tls_insecure: boolean(),
+          tls_replication: boolean(),
+          tls_cluster: boolean(),
           # Replication
           replicaof: {String.t(), non_neg_integer()} | nil,
+          masteruser: String.t() | nil,
           masterauth: String.t() | nil,
           # Cluster
           cluster_enabled: boolean(),
@@ -76,6 +87,7 @@ defmodule RedisServerWrapper.Config do
   defstruct port: 6379,
             bind: "127.0.0.1",
             control_host: nil,
+            username: nil,
             password: nil,
             loglevel: :notice,
             logfile: nil,
@@ -96,8 +108,16 @@ defmodule RedisServerWrapper.Config do
             tls_cert_file: nil,
             tls_key_file: nil,
             tls_ca_cert_file: nil,
+            tls_ca_cert_dir: nil,
             tls_auth_clients: nil,
+            tls_client_cert_file: nil,
+            tls_client_key_file: nil,
+            tls_server_name: nil,
+            tls_insecure: false,
+            tls_replication: false,
+            tls_cluster: false,
             replicaof: nil,
+            masteruser: nil,
             masterauth: nil,
             cluster_enabled: false,
             cluster_config_file: nil,
@@ -146,6 +166,38 @@ defmodule RedisServerWrapper.Config do
   @spec listen_addresses(t()) :: [String.t()]
   def listen_addresses(%__MODULE__{bind: bind}), do: bind_tokens(bind)
 
+  @doc "Builds the client connection used to control this Redis server."
+  @spec connection(t()) :: Connection.t()
+  def connection(%__MODULE__{} = config) do
+    common = [
+      username: config.username,
+      password: config.password
+    ]
+
+    cond do
+      is_integer(config.tls_port) and config.tls_port > 0 ->
+        Connection.new(
+          [
+            transport: :tls,
+            host: control_host(config),
+            port: config.tls_port,
+            tls_ca_cert_file: config.tls_ca_cert_file,
+            tls_ca_cert_dir: config.tls_ca_cert_dir,
+            tls_client_cert_file: config.tls_client_cert_file,
+            tls_client_key_file: config.tls_client_key_file,
+            tls_server_name: config.tls_server_name,
+            tls_insecure: config.tls_insecure
+          ] ++ common
+        )
+
+      is_integer(config.port) and config.port > 0 ->
+        Connection.new([transport: :tcp, host: control_host(config), port: config.port] ++ common)
+
+      is_binary(config.unixsocket) ->
+        Connection.new([transport: :unix, socket: config.unixsocket] ++ common)
+    end
+  end
+
   @doc """
   Encodes one Redis configuration directive from an argument vector.
 
@@ -166,7 +218,7 @@ defmodule RedisServerWrapper.Config do
     []
     |> emit("port", config.port)
     |> emit("bind", bind_tokens(config.bind))
-    |> emit_if("requirepass", config.password)
+    |> emit_auth(config)
     |> emit("loglevel", config.loglevel)
     |> emit_if("logfile", config.logfile)
     |> emit("daemonize", yn(config.daemonize))
@@ -212,6 +264,20 @@ defmodule RedisServerWrapper.Config do
     end)
   end
 
+  defp emit_auth(acc, %{username: nil, password: password}) do
+    emit_if(acc, "requirepass", password)
+  end
+
+  defp emit_auth(acc, %{username: "default", password: password}) do
+    emit(acc, "user", ["default", "on", ">#{password}", "~*", "&*", "+@all"])
+  end
+
+  defp emit_auth(acc, %{username: username, password: password}) do
+    acc
+    |> emit("user", ["default", "off"])
+    |> emit("user", [username, "on", ">#{password}", "~*", "&*", "+@all"])
+  end
+
   defp emit_tls(acc, %{tls_port: nil}), do: acc
 
   defp emit_tls(acc, config) do
@@ -220,7 +286,10 @@ defmodule RedisServerWrapper.Config do
     |> emit_if("tls-cert-file", config.tls_cert_file)
     |> emit_if("tls-key-file", config.tls_key_file)
     |> emit_if("tls-ca-cert-file", config.tls_ca_cert_file)
+    |> emit_if("tls-ca-cert-dir", config.tls_ca_cert_dir)
     |> emit_if("tls-auth-clients", config.tls_auth_clients)
+    |> emit_if_true("tls-replication", config.tls_replication)
+    |> emit_if_true("tls-cluster", config.tls_cluster)
   end
 
   defp emit_replication(acc, %{replicaof: nil}), do: acc
@@ -230,6 +299,7 @@ defmodule RedisServerWrapper.Config do
 
     acc
     |> emit("replicaof", [host, port])
+    |> emit_if("masteruser", config.masteruser)
     |> emit_if("masterauth", config.masterauth)
   end
 
@@ -264,10 +334,11 @@ defmodule RedisServerWrapper.Config do
   end
 
   @reserved_directives MapSet.new(~w(
-    port bind requirepass loglevel logfile daemonize pidfile dir save
+    port bind requirepass user loglevel logfile daemonize pidfile dir save
     appendonly appendfsync maxmemory maxmemory-policy tcp-backlog timeout
     tcp-keepalive unixsocket unixsocketperm tls-port tls-cert-file
-    tls-key-file tls-ca-cert-file tls-auth-clients replicaof masterauth
+    tls-key-file tls-ca-cert-file tls-ca-cert-dir tls-auth-clients
+    tls-replication tls-cluster replicaof masteruser masterauth
     cluster-enabled cluster-config-file cluster-node-timeout
     cluster-announce-hostname cluster-announce-port cluster-announce-bus-port
     loadmodule
@@ -279,7 +350,10 @@ defmodule RedisServerWrapper.Config do
     validate_boolean!(:daemonize, config.daemonize)
     validate_boolean!(:appendonly, config.appendonly)
     validate_boolean!(:cluster_enabled, config.cluster_enabled)
-    validate_port!(:port, config.port)
+    validate_boolean!(:tls_insecure, config.tls_insecure)
+    validate_boolean!(:tls_replication, config.tls_replication)
+    validate_boolean!(:tls_cluster, config.tls_cluster)
+    validate_listen_port!(:port, config.port)
 
     Enum.each(
       [
@@ -305,6 +379,7 @@ defmodule RedisServerWrapper.Config do
 
     Enum.each(
       [
+        username: config.username,
         password: config.password,
         logfile: config.logfile,
         pidfile: config.pidfile,
@@ -316,7 +391,12 @@ defmodule RedisServerWrapper.Config do
         tls_cert_file: config.tls_cert_file,
         tls_key_file: config.tls_key_file,
         tls_ca_cert_file: config.tls_ca_cert_file,
+        tls_ca_cert_dir: config.tls_ca_cert_dir,
         tls_auth_clients: config.tls_auth_clients,
+        tls_client_cert_file: config.tls_client_cert_file,
+        tls_client_key_file: config.tls_client_key_file,
+        tls_server_name: config.tls_server_name,
+        masteruser: config.masteruser,
         masterauth: config.masterauth,
         cluster_config_file: config.cluster_config_file,
         cluster_announce_hostname: config.cluster_announce_hostname
@@ -325,7 +405,12 @@ defmodule RedisServerWrapper.Config do
     )
 
     validate_save!(config.save)
+    validate_auth!(config)
+    validate_tls!(config)
+    validate_endpoint!(config)
+    validate_unix_socket!(config.unixsocket)
     validate_replicaof!(config.replicaof)
+    validate_replication_auth!(config)
     validate_modules!(config.loadmodule)
     validate_extra!(config.extra)
   end
@@ -346,6 +431,14 @@ defmodule RedisServerWrapper.Config do
 
   defp validate_port!(field, value) do
     raise ArgumentError, ":#{field} must be an integer from 1 to 65535, got: #{inspect(value)}"
+  end
+
+  defp validate_listen_port!(_field, value)
+       when is_integer(value) and value in 0..65_535,
+       do: :ok
+
+  defp validate_listen_port!(field, value) do
+    raise ArgumentError, ":#{field} must be an integer from 0 to 65535, got: #{inspect(value)}"
   end
 
   defp validate_optional_port!(_field, nil), do: :ok
@@ -387,6 +480,9 @@ defmodule RedisServerWrapper.Config do
     host = control_host(config)
 
     cond do
+      config.port == 0 and is_nil(config.tls_port) ->
+        :ok
+
       not is_binary(host) or host == "" or Regex.match?(~r/\s/u, host) ->
         raise ArgumentError, ":control_host must resolve to one non-empty address"
 
@@ -397,6 +493,116 @@ defmodule RedisServerWrapper.Config do
       true ->
         :ok
     end
+  end
+
+  defp validate_auth!(%{username: nil}), do: :ok
+
+  defp validate_auth!(%{username: username, password: password})
+       when is_binary(username) and username != "" and is_binary(password),
+       do: :ok
+
+  defp validate_auth!(config) do
+    raise ArgumentError,
+          ":username requires a non-empty username and string :password, got: " <>
+            "#{inspect(config.username)} / #{inspect(config.password)}"
+  end
+
+  defp validate_tls!(%{tls_port: nil} = config) do
+    tls_options = [
+      config.tls_cert_file,
+      config.tls_key_file,
+      config.tls_ca_cert_file,
+      config.tls_ca_cert_dir,
+      config.tls_auth_clients,
+      config.tls_client_cert_file,
+      config.tls_client_key_file,
+      config.tls_server_name
+    ]
+
+    if config.tls_insecure or config.tls_replication or config.tls_cluster or
+         Enum.any?(tls_options, &is_binary/1) do
+      raise ArgumentError, "TLS options require :tls_port"
+    end
+  end
+
+  defp validate_tls!(config) do
+    validate_tls_server_identity!(config)
+    validate_tls_ca!(config)
+    validate_tls_auth_clients!(config)
+    validate_tls_client_identity!(config)
+    _connection = connection(config)
+    :ok
+  end
+
+  defp validate_tls_server_identity!(config) do
+    required = [
+      tls_cert_file: config.tls_cert_file,
+      tls_key_file: config.tls_key_file
+    ]
+
+    case Enum.find(required, fn {_key, value} -> not (is_binary(value) and value != "") end) do
+      {key, _value} -> raise ArgumentError, ":#{key} is required when :tls_port is set"
+      nil -> :ok
+    end
+  end
+
+  defp validate_tls_ca!(config) do
+    if is_nil(config.tls_ca_cert_file) and is_nil(config.tls_ca_cert_dir) do
+      raise ArgumentError,
+            ":tls_ca_cert_file or :tls_ca_cert_dir is required when :tls_port is set"
+    end
+
+    if config.tls_ca_cert_file && config.tls_ca_cert_dir do
+      raise ArgumentError, "set only one of :tls_ca_cert_file and :tls_ca_cert_dir"
+    end
+  end
+
+  defp validate_tls_auth_clients!(config) do
+    if config.tls_auth_clients not in [nil, "yes", "no", "optional"] do
+      raise ArgumentError, ":tls_auth_clients must be \"yes\", \"no\", \"optional\", or nil"
+    end
+  end
+
+  defp validate_tls_client_identity!(config) do
+    if config.tls_auth_clients in [nil, "yes"] and
+         (is_nil(config.tls_client_cert_file) or is_nil(config.tls_client_key_file)) do
+      raise ArgumentError,
+            "Redis requires TLS client certificates by default; set " <>
+              ":tls_client_cert_file and :tls_client_key_file, or set " <>
+              ":tls_auth_clients to \"no\" or \"optional\""
+    end
+  end
+
+  defp validate_endpoint!(config) do
+    unless config.port > 0 or not is_nil(config.tls_port) or not is_nil(config.unixsocket) do
+      raise ArgumentError, "at least one of :port, :tls_port, or :unixsocket must be enabled"
+    end
+  end
+
+  # sockaddr_un.sun_path is 104 bytes on macOS and 108 on Linux. Keep one byte
+  # for the terminator and enforce the portable lower bound before Redis starts.
+  defp validate_unix_socket!(nil), do: :ok
+
+  defp validate_unix_socket!(path) when byte_size(path) <= 103, do: :ok
+
+  defp validate_unix_socket!(path) do
+    raise ArgumentError,
+          ":unixsocket must be at most 103 bytes for portable Unix-socket support, got: " <>
+            "#{byte_size(path)}"
+  end
+
+  defp validate_replication_auth!(%{replicaof: nil, masteruser: nil, masterauth: nil}), do: :ok
+
+  defp validate_replication_auth!(%{replicaof: nil}) do
+    raise ArgumentError, ":masteruser and :masterauth require :replicaof"
+  end
+
+  defp validate_replication_auth!(%{masteruser: nil}), do: :ok
+
+  defp validate_replication_auth!(%{masterauth: masterauth}) when is_binary(masterauth), do: :ok
+
+  defp validate_replication_auth!(_config) do
+    raise ArgumentError, ":masteruser requires :masterauth"
   end
 
   defp validate_save!(:default), do: :ok
@@ -529,4 +735,7 @@ defmodule RedisServerWrapper.Config do
 
   defp yn(true), do: "yes"
   defp yn(false), do: "no"
+
+  defp emit_if_true(acc, _key, false), do: acc
+  defp emit_if_true(acc, key, true), do: emit(acc, key, "yes")
 end

--- a/lib/redis_server_wrapper/connection.ex
+++ b/lib/redis_server_wrapper/connection.ex
@@ -1,0 +1,301 @@
+defmodule RedisServerWrapper.Connection do
+  @moduledoc """
+  A Redis client connection shared by lifecycle and topology APIs.
+
+  The connection keeps the endpoint, authentication, and TLS client settings
+  together so readiness, commands, health checks, shutdown, and persisted
+  Manager instances all use the same transport.
+  """
+
+  @type transport :: :tcp | :tls | :unix
+
+  @type t :: %__MODULE__{
+          transport: transport(),
+          host: String.t() | nil,
+          port: :inet.port_number() | nil,
+          socket: String.t() | nil,
+          username: String.t() | nil,
+          password: String.t() | nil,
+          tls_ca_cert_file: String.t() | nil,
+          tls_ca_cert_dir: String.t() | nil,
+          tls_client_cert_file: String.t() | nil,
+          tls_client_key_file: String.t() | nil,
+          tls_server_name: String.t() | nil,
+          tls_insecure: boolean()
+        }
+
+  @derive {JSON.Encoder,
+           only: [
+             :transport,
+             :host,
+             :port,
+             :socket,
+             :username,
+             :password,
+             :tls_ca_cert_file,
+             :tls_ca_cert_dir,
+             :tls_client_cert_file,
+             :tls_client_key_file,
+             :tls_server_name,
+             :tls_insecure
+           ]}
+  defstruct transport: :tcp,
+            host: "127.0.0.1",
+            port: 6379,
+            socket: nil,
+            username: nil,
+            password: nil,
+            tls_ca_cert_file: nil,
+            tls_ca_cert_dir: nil,
+            tls_client_cert_file: nil,
+            tls_client_key_file: nil,
+            tls_server_name: nil,
+            tls_insecure: false
+
+  @doc "Creates and validates a connection."
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) do
+    connection = struct!(__MODULE__, opts)
+    validate!(connection)
+    connection
+  end
+
+  @doc false
+  @spec from_map(map()) :: t()
+  def from_map(map) when is_map(map) do
+    defaults = Map.from_struct(%__MODULE__{})
+    fields = Map.keys(defaults)
+
+    opts =
+      Enum.map(fields, fn field ->
+        value =
+          Map.get(map, field, Map.get(map, Atom.to_string(field), Map.fetch!(defaults, field)))
+
+        {field, normalize_loaded_value(field, value)}
+      end)
+
+    new(opts)
+  end
+
+  @doc "Returns a copy of a TCP or TLS connection using another port."
+  @spec with_port(t(), :inet.port_number()) :: t()
+  def with_port(%__MODULE__{transport: transport} = connection, port)
+      when transport in [:tcp, :tls] do
+    connection
+    |> Map.from_struct()
+    |> Map.put(:port, port)
+    |> Map.to_list()
+    |> new()
+  end
+
+  @doc "Returns the listener used for ownership and availability checks."
+  @spec listener(t()) :: {:tcp, String.t(), :inet.port_number()} | {:unix, String.t()}
+  def listener(%__MODULE__{transport: :unix, socket: socket}), do: {:unix, socket}
+
+  def listener(%__MODULE__{host: host, port: port}) do
+    {:tcp, host, port}
+  end
+
+  @doc "Returns the redis-cli connection argument vector."
+  @spec cli_args(t(), keyword()) :: [String.t()]
+  def cli_args(%__MODULE__{} = connection, opts \\ []) do
+    include_endpoint = Keyword.get(opts, :include_endpoint, true)
+
+    []
+    |> append_endpoint(connection, include_endpoint)
+    |> append_username(connection.username)
+    |> append_tls(connection)
+  end
+
+  @doc "Returns environment variables used to pass secrets to redis-cli."
+  @spec cli_env(t()) :: [{String.t(), String.t()}]
+  def cli_env(%__MODULE__{password: nil}), do: []
+  def cli_env(%__MODULE__{password: password}), do: [{"REDISCLI_AUTH", password}]
+
+  @doc "Returns a Redis URL for display or client handoff."
+  @spec url(t()) :: String.t()
+  def url(%__MODULE__{transport: :unix, socket: socket}) do
+    "unix://#{URI.encode(socket)}"
+  end
+
+  def url(%__MODULE__{} = connection) do
+    scheme = if connection.transport == :tls, do: "rediss", else: "redis"
+    credentials = encoded_credentials(connection)
+    "#{scheme}://#{credentials}#{url_host(connection.host)}:#{connection.port}"
+  end
+
+  @doc "Returns a stable, filesystem-safe endpoint identifier."
+  @spec id(t()) :: String.t()
+  def id(%__MODULE__{transport: :unix, socket: socket}) do
+    hash = :crypto.hash(:sha256, socket) |> Base.encode16(case: :lower) |> binary_part(0, 12)
+    "unix-#{hash}"
+  end
+
+  def id(%__MODULE__{port: port}), do: Integer.to_string(port)
+
+  @doc "Returns a concise endpoint label suitable for errors and logs."
+  @spec label(t()) :: String.t()
+  def label(%__MODULE__{transport: :unix, socket: socket}), do: socket
+  def label(%__MODULE__{host: host, port: port}), do: "#{host}:#{port}"
+
+  defp append_endpoint(args, _connection, false), do: args
+
+  defp append_endpoint(args, %__MODULE__{transport: :unix, socket: socket}, true) do
+    args ++ ["-s", socket]
+  end
+
+  defp append_endpoint(args, %__MODULE__{host: host, port: port}, true) do
+    args ++ ["-h", host, "-p", to_string(port)]
+  end
+
+  defp append_username(args, nil), do: args
+  defp append_username(args, username), do: args ++ ["--user", username]
+
+  defp append_tls(args, %__MODULE__{transport: transport}) when transport != :tls, do: args
+
+  defp append_tls(args, connection) do
+    args
+    |> Kernel.++(["--tls"])
+    |> maybe_append(connection.tls_ca_cert_file, "--cacert")
+    |> maybe_append(connection.tls_ca_cert_dir, "--cacertdir")
+    |> maybe_append(connection.tls_client_cert_file, "--cert")
+    |> maybe_append(connection.tls_client_key_file, "--key")
+    |> maybe_append(connection.tls_server_name, "--sni")
+    |> maybe_append_flag(connection.tls_insecure, "--insecure")
+  end
+
+  defp maybe_append(args, nil, _flag), do: args
+  defp maybe_append(args, value, flag), do: args ++ [flag, value]
+
+  defp maybe_append_flag(args, false, _flag), do: args
+  defp maybe_append_flag(args, true, flag), do: args ++ [flag]
+
+  defp encoded_credentials(%__MODULE__{username: nil, password: nil}), do: ""
+
+  defp encoded_credentials(%__MODULE__{username: nil, password: password}) do
+    ":#{encode_uri(password)}@"
+  end
+
+  defp encoded_credentials(%__MODULE__{username: username, password: password}) do
+    "#{encode_uri(username)}:#{encode_uri(password)}@"
+  end
+
+  defp encode_uri(value), do: URI.encode(value, &URI.char_unreserved?/1)
+
+  defp url_host(host) do
+    if String.contains?(host, ":") and not String.starts_with?(host, "[") do
+      "[#{host}]"
+    else
+      host
+    end
+  end
+
+  defp validate!(%__MODULE__{} = connection) do
+    validate_transport!(connection)
+    validate_auth!(connection)
+    validate_tls_options!(connection)
+    validate_tls_client_pair!(connection)
+    connection
+  end
+
+  defp validate_transport!(%__MODULE__{transport: :unix, socket: socket}) do
+    unless is_binary(socket) and socket != "" do
+      raise ArgumentError, ":socket must be a non-empty path for a Unix connection"
+    end
+  end
+
+  defp validate_transport!(%__MODULE__{transport: transport, host: host, port: port})
+       when transport in [:tcp, :tls] do
+    unless is_binary(host) and host != "" do
+      raise ArgumentError, ":host must be a non-empty string"
+    end
+
+    unless is_integer(port) and port in 1..65_535 do
+      raise ArgumentError, ":port must be an integer from 1 to 65535"
+    end
+  end
+
+  defp validate_transport!(%__MODULE__{transport: transport}) do
+    raise ArgumentError, ":transport must be :tcp, :tls, or :unix, got: #{inspect(transport)}"
+  end
+
+  defp validate_auth!(%__MODULE__{username: nil, password: password})
+       when is_nil(password) or is_binary(password),
+       do: :ok
+
+  defp validate_auth!(%__MODULE__{username: username, password: password})
+       when is_binary(username) and username != "" and is_binary(password),
+       do: :ok
+
+  defp validate_auth!(%__MODULE__{username: username, password: password}) do
+    raise ArgumentError,
+          ":username requires a non-empty username and string password, got: " <>
+            "#{inspect(username)} / #{inspect(password)}"
+  end
+
+  defp validate_tls_options!(connection) do
+    Enum.each(
+      [
+        tls_ca_cert_file: connection.tls_ca_cert_file,
+        tls_ca_cert_dir: connection.tls_ca_cert_dir,
+        tls_client_cert_file: connection.tls_client_cert_file,
+        tls_client_key_file: connection.tls_client_key_file,
+        tls_server_name: connection.tls_server_name
+      ],
+      fn
+        {_field, nil} ->
+          :ok
+
+        {_field, value} when is_binary(value) and value != "" ->
+          :ok
+
+        {field, value} ->
+          raise ArgumentError,
+                ":#{field} must be a non-empty string or nil, got: #{inspect(value)}"
+      end
+    )
+
+    unless is_boolean(connection.tls_insecure) do
+      raise ArgumentError, ":tls_insecure must be a boolean"
+    end
+
+    tls_options? =
+      connection.tls_insecure or
+        Enum.any?(
+          [
+            connection.tls_ca_cert_file,
+            connection.tls_ca_cert_dir,
+            connection.tls_client_cert_file,
+            connection.tls_client_key_file,
+            connection.tls_server_name
+          ],
+          &is_binary/1
+        )
+
+    if connection.transport != :tls and tls_options? do
+      raise ArgumentError, "TLS client options require transport: :tls"
+    end
+  end
+
+  defp validate_tls_client_pair!(%__MODULE__{
+         tls_client_cert_file: nil,
+         tls_client_key_file: nil
+       }),
+       do: :ok
+
+  defp validate_tls_client_pair!(%__MODULE__{
+         tls_client_cert_file: cert,
+         tls_client_key_file: key
+       })
+       when is_binary(cert) and cert != "" and is_binary(key) and key != "",
+       do: :ok
+
+  defp validate_tls_client_pair!(_connection) do
+    raise ArgumentError, ":tls_client_cert_file and :tls_client_key_file must be set together"
+  end
+
+  defp normalize_loaded_value(:transport, "tcp"), do: :tcp
+  defp normalize_loaded_value(:transport, "tls"), do: :tls
+  defp normalize_loaded_value(:transport, "unix"), do: :unix
+  defp normalize_loaded_value(_field, value), do: value
+end

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -22,11 +22,27 @@ defmodule RedisServerWrapper.Manager do
   the same state file concurrently.
   """
 
-  alias RedisServerWrapper.{Cli, Cluster, OSProcess, SecureFile, Sentinel, Server}
+  alias RedisServerWrapper.{Cli, Cluster, Connection, OSProcess, SecureFile, Sentinel, Server}
 
   require Logger
 
   @default_state_file Path.expand("~/.config/redis-server-wrapper/instances.json")
+  @connection_option_keys [
+    :username,
+    :unixsocket,
+    :unixsocketperm,
+    :tls,
+    :tls_port,
+    :tls_cert_file,
+    :tls_key_file,
+    :tls_ca_cert_file,
+    :tls_ca_cert_dir,
+    :tls_auth_clients,
+    :tls_client_cert_file,
+    :tls_client_key_file,
+    :tls_server_name,
+    :tls_insecure
+  ]
 
   @type instance_type :: :basic | :cluster | :sentinel
   @type instance :: %{
@@ -36,7 +52,9 @@ defmodule RedisServerWrapper.Manager do
           bind: String.t(),
           ports: [non_neg_integer()],
           pids: [non_neg_integer()],
+          username: String.t() | nil,
           password: String.t() | nil,
+          connection: Connection.t(),
           url: String.t(),
           metadata: map()
         }
@@ -53,12 +71,14 @@ defmodule RedisServerWrapper.Manager do
     * `:name` - instance name (auto-generated if omitted)
     * `:port` - Redis port (default: 6379)
     * `:password` - Redis password (auto-generated if omitted, pass `nil` for no auth)
+    * `:username` - optional ACL username paired with `:password`
     * `:bind` - bind address (default: "127.0.0.1")
     * `:control_host` - address used for client and lifecycle operations
     * `:persist` - enable persistence (default: false)
     * `:maxmemory` - memory limit (e.g., "256mb")
     * `:loadmodule` - modules to load; accepts paths or `{path, [args]}` tuples
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
+    * TCP, Unix-socket, and TLS options accepted by `RedisServerWrapper.Server`
     * Plus any `RedisServerWrapper.Config` options via `:extra`
   """
   @spec start_basic(keyword()) :: {:ok, instance()} | {:error, term()}
@@ -93,7 +113,10 @@ defmodule RedisServerWrapper.Manager do
           managed: false,
           distribution: distribution,
           loadmodule: loadmodule
-        ]
+        ] ++ server_connection_options(opts)
+
+      server_opts =
+        server_opts
         |> maybe_put(:maxmemory, maxmemory)
         |> maybe_put(:extra, if(extra != [], do: extra))
 
@@ -107,11 +130,13 @@ defmodule RedisServerWrapper.Manager do
             name: name,
             type: :basic,
             created_at: DateTime.utc_now() |> DateTime.to_iso8601(),
-            bind: info.host,
-            ports: [port],
+            bind: info.connection.host || info.host,
+            ports: connection_ports(info.connection),
             pids: [info.pid],
+            username: info.connection.username,
             password: password,
-            url: build_url(info.host, port, password),
+            connection: info.connection,
+            url: Connection.url(info.connection),
             metadata: %{
               persist: persist,
               maxmemory: maxmemory,
@@ -139,10 +164,12 @@ defmodule RedisServerWrapper.Manager do
     * `:replicas_per_master` - replicas per master (default: 0)
     * `:base_port` - starting port (default: 7100)
     * `:password` - Redis password (auto-generated if omitted)
+    * `:username` - optional ACL username paired with `:password`
     * `:bind` - bind address (default: "127.0.0.1")
     * `:control_host` - address used for client and cluster operations
     * `:loadmodule` - modules loaded into every cluster node
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
+    * TLS options accepted by `RedisServerWrapper.Cluster`
   """
   @spec start_cluster(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_cluster(opts \\ []) do
@@ -164,17 +191,18 @@ defmodule RedisServerWrapper.Manager do
     if Map.has_key?(state.instances, name) do
       {:error, {:instance_exists, name}}
     else
-      cluster_opts = [
-        masters: masters,
-        replicas_per_master: replicas,
-        base_port: base_port,
-        bind: bind,
-        control_host: control_host,
-        password: password,
-        managed: false,
-        distribution: distribution,
-        loadmodule: loadmodule
-      ]
+      cluster_opts =
+        [
+          masters: masters,
+          replicas_per_master: replicas,
+          base_port: base_port,
+          bind: bind,
+          control_host: control_host,
+          password: password,
+          managed: false,
+          distribution: distribution,
+          loadmodule: loadmodule
+        ] ++ connection_options(opts)
 
       case Cluster.start(cluster_opts) do
         {:ok, pid} ->
@@ -197,8 +225,10 @@ defmodule RedisServerWrapper.Manager do
             bind: cluster_info.control_host,
             ports: ports,
             pids: os_pids,
+            username: cluster_info.connection.username,
             password: password,
-            url: build_url(cluster_info.control_host, base_port, password),
+            connection: cluster_info.connection,
+            url: Connection.url(cluster_info.connection),
             metadata: %{
               masters: masters,
               replicas_per_master: replicas
@@ -227,9 +257,11 @@ defmodule RedisServerWrapper.Manager do
     * `:quorum` - Sentinel quorum (default: min(2, sentinels))
     * `:sentinel_base_port` - starting sentinel port (default: 26389)
     * `:password` - Redis password (auto-generated if omitted)
+    * `:username` - optional ACL username paired with `:password`
     * `:bind` - bind address (default: "127.0.0.1")
     * `:loadmodule` - modules loaded into the master and every replica
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
+    * TLS options accepted by `RedisServerWrapper.Sentinel`
   """
   @spec start_sentinel(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_sentinel(opts \\ []) do
@@ -253,19 +285,20 @@ defmodule RedisServerWrapper.Manager do
     if Map.has_key?(state.instances, name) do
       {:error, {:instance_exists, name}}
     else
-      sentinel_opts = [
-        master_port: master_port,
-        replicas: num_replicas,
-        sentinels: num_sentinels,
-        quorum: quorum,
-        sentinel_base_port: sentinel_base_port,
-        bind: bind,
-        control_host: control_host,
-        password: password,
-        managed: false,
-        distribution: distribution,
-        loadmodule: loadmodule
-      ]
+      sentinel_opts =
+        [
+          master_port: master_port,
+          replicas: num_replicas,
+          sentinels: num_sentinels,
+          quorum: quorum,
+          sentinel_base_port: sentinel_base_port,
+          bind: bind,
+          control_host: control_host,
+          password: password,
+          managed: false,
+          distribution: distribution,
+          loadmodule: loadmodule
+        ] ++ connection_options(opts)
 
       case Sentinel.start(sentinel_opts) do
         {:ok, pid} ->
@@ -301,8 +334,10 @@ defmodule RedisServerWrapper.Manager do
             bind: sen_info.control_host,
             ports: all_redis_ports ++ sentinel_ports,
             pids: redis_pids ++ sentinel_pids,
+            username: sen_info.master_connection.username,
             password: password,
-            url: build_url(sen_info.control_host, master_port, password),
+            connection: sen_info.master_connection,
+            url: Connection.url(sen_info.master_connection),
             metadata: %{
               master_name: sen_info.master_name,
               master_port: master_port,
@@ -377,7 +412,8 @@ defmodule RedisServerWrapper.Manager do
   caller explicitly needs the plaintext password or connection URL.
   """
   @spec credentials(String.t()) ::
-          {:ok, %{password: String.t() | nil, url: String.t()}} | {:error, :not_found}
+          {:ok, %{username: String.t() | nil, password: String.t() | nil, url: String.t()}}
+          | {:error, :not_found}
   def credentials(name) do
     state = load_state()
 
@@ -388,8 +424,9 @@ defmodule RedisServerWrapper.Manager do
       instance ->
         {:ok,
          %{
+           username: instance_connection(instance).username,
            password: instance.password,
-           url: build_url(instance.bind, List.first(instance.ports), instance.password)
+           url: Connection.url(instance_connection(instance))
          }}
     end
   end
@@ -609,6 +646,8 @@ defmodule RedisServerWrapper.Manager do
   defp deserialize_state(_data), do: raise(ArgumentError, "Manager state must be an object")
 
   defp deserialize_instance(name, inst) when is_map(inst) do
+    connection = deserialize_connection(inst)
+
     %{
       name: inst["name"] || name,
       type: deserialize_type(inst["type"] || "basic"),
@@ -616,7 +655,9 @@ defmodule RedisServerWrapper.Manager do
       bind: inst["bind"] || "127.0.0.1",
       ports: inst["ports"] || [],
       pids: inst["pids"] || [],
+      username: inst["username"] || connection.username,
       password: inst["password"],
+      connection: connection,
       url: inst["url"] || "",
       metadata: atomize_keys(inst["metadata"] || %{})
     }
@@ -629,6 +670,25 @@ defmodule RedisServerWrapper.Manager do
   defp deserialize_type("cluster"), do: :cluster
   defp deserialize_type("sentinel"), do: :sentinel
   defp deserialize_type(type), do: raise(ArgumentError, "unknown Manager instance type: #{type}")
+
+  defp deserialize_connection(%{"connection" => connection}) when is_map(connection) do
+    Connection.from_map(connection)
+  end
+
+  defp deserialize_connection(instance) do
+    port =
+      case instance["ports"] || [] do
+        [port | _rest] when is_integer(port) and port > 0 -> port
+        _other -> 6379
+      end
+
+    Connection.new(
+      host: instance["bind"] || "127.0.0.1",
+      port: port,
+      username: instance["username"],
+      password: instance["password"]
+    )
+  end
 
   defp atomize_keys(map) when is_map(map) do
     Map.new(map, fn
@@ -737,31 +797,60 @@ defmodule RedisServerWrapper.Manager do
 
   defp owned_listeners(instance) do
     Enum.reduce_while(
-      instance.ports,
+      listener_targets(instance),
       {:ok, %{}},
       &collect_owned_listener(&1, &2, instance)
     )
   end
 
-  defp collect_owned_listener(port, {:ok, listeners}, instance) do
-    case OSProcess.pids_on_port(port) do
-      {:ok, port_pids} ->
-        owned_pids = Enum.filter(port_pids, &(&1 in instance.pids))
-        {:cont, {:ok, maybe_put_listener(listeners, port, owned_pids)}}
+  defp collect_owned_listener(target, {:ok, listeners}, instance) do
+    case pids_on_target(target) do
+      {:ok, target_pids} ->
+        owned_pids = Enum.filter(target_pids, &(&1 in instance.pids))
+        {:cont, {:ok, maybe_put_listener(listeners, target, owned_pids)}}
 
       {:error, reason} ->
         {:halt, {:error, {:process_ownership_not_verified, instance.name, reason}}}
     end
   end
 
-  defp maybe_put_listener(listeners, _port, []), do: listeners
-  defp maybe_put_listener(listeners, port, pids), do: Map.put(listeners, port, pids)
+  defp maybe_put_listener(listeners, _target, []), do: listeners
+  defp maybe_put_listener(listeners, target, pids), do: Map.put(listeners, target, pids)
 
   defp gracefully_stop_owned_listeners(instance, listeners) do
-    Enum.each(Map.keys(listeners), fn port ->
-      cli = Cli.new(host: instance.bind, port: port, password: instance.password)
+    Enum.each(Map.keys(listeners), fn target ->
+      cli = Cli.new(connection: connection_for_target(instance, target))
       _result = Cli.run(cli, ["SHUTDOWN", "NOSAVE"])
     end)
+  end
+
+  defp listener_targets(instance) do
+    case instance_connection(instance) do
+      %Connection{transport: :unix, socket: socket} -> [{:unix, socket}]
+      _connection -> Enum.map(instance.ports, &{:tcp, &1})
+    end
+  end
+
+  defp pids_on_target({:tcp, port}), do: OSProcess.pids_on_port(port)
+  defp pids_on_target({:unix, socket}), do: OSProcess.pids_on_socket(socket)
+
+  defp connection_for_target(instance, {:tcp, port}) do
+    instance |> instance_connection() |> Connection.with_port(port)
+  end
+
+  defp connection_for_target(instance, {:unix, _socket}), do: instance_connection(instance)
+
+  defp instance_connection(%{connection: %Connection{} = connection}), do: connection
+
+  defp instance_connection(instance) do
+    port = Enum.find(instance.ports, 6379, &(&1 > 0))
+
+    Connection.new(
+      host: instance.bind,
+      port: port,
+      username: Map.get(instance, :username),
+      password: instance.password
+    )
   end
 
   defp signal_owned_listeners(instance, signal) do
@@ -820,24 +909,8 @@ defmodule RedisServerWrapper.Manager do
   defp ports_from(_base_port, 0), do: []
   defp ports_from(base_port, count), do: Enum.map(0..(count - 1), &(base_port + &1))
 
-  # -------------------------------------------------------------------
-  # URL building
-  # -------------------------------------------------------------------
-
-  defp build_url(host, port, nil), do: "redis://#{url_host(host)}:#{port}"
-
-  defp build_url(host, port, password) do
-    encoded_password = URI.encode(password, &URI.char_unreserved?/1)
-    "redis://:#{encoded_password}@#{url_host(host)}:#{port}"
-  end
-
-  defp url_host(host) do
-    if String.contains?(host, ":") and not String.starts_with?(host, "[") do
-      "[#{host}]"
-    else
-      host
-    end
-  end
+  defp connection_ports(%Connection{transport: :unix}), do: []
+  defp connection_ports(%Connection{port: port}), do: [port]
 
   # -------------------------------------------------------------------
   # Display helpers
@@ -897,4 +970,12 @@ defmodule RedisServerWrapper.Manager do
 
   defp maybe_put(opts, _key, nil), do: opts
   defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp connection_options(opts), do: Keyword.take(opts, @connection_option_keys)
+
+  defp server_connection_options(opts) do
+    opts
+    |> connection_options()
+    |> Keyword.delete(:tls)
+  end
 end

--- a/lib/redis_server_wrapper/os_process.ex
+++ b/lib/redis_server_wrapper/os_process.ex
@@ -81,6 +81,29 @@ defmodule RedisServerWrapper.OSProcess do
     end
   end
 
+  @spec pids_on_socket(String.t()) ::
+          {:ok, [pos_integer()]} | {:error, {:executable_not_found, String.t()}}
+  def pids_on_socket(path) when is_binary(path) and path != "" do
+    case System.find_executable("lsof") do
+      nil ->
+        {:error, {:executable_not_found, "lsof"}}
+
+      lsof ->
+        case System.cmd(lsof, ["-t", "--", path], stderr_to_stdout: true) do
+          {output, 0} ->
+            pids =
+              output
+              |> String.split(~r/\s+/, trim: true)
+              |> Enum.flat_map(&parse_pid/1)
+
+            {:ok, pids}
+
+          _other ->
+            {:ok, []}
+        end
+    end
+  end
+
   defp signal_arg(:term), do: "-TERM"
   defp signal_arg(:kill), do: "-9"
   defp signal_arg(:stop), do: "-STOP"

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -29,6 +29,13 @@ defmodule RedisServerWrapper.Sentinel do
     * `:control_host` - address used by redis-cli, replication, and Sentinel
       monitoring (default: first bind address)
     * `:password` - Redis password
+    * `:username` - optional ACL username paired with `:password`
+    * `:tls` - use TLS-only data-node and Sentinel connections (default: false)
+    * `:tls_cert_file`, `:tls_key_file` - server certificate and private key
+    * `:tls_ca_cert_file` or `:tls_ca_cert_dir` - trusted CA for Redis and redis-cli
+    * `:tls_client_cert_file`, `:tls_client_key_file` - optional redis-cli client identity
+    * `:tls_server_name` - optional redis-cli SNI name
+    * `:tls_insecure` - explicitly disable redis-cli certificate verification
     * `:redis_server_bin` - redis-server binary path
     * `:redis_cli_bin` - redis-cli binary path
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
@@ -44,7 +51,7 @@ defmodule RedisServerWrapper.Sentinel do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Config, OSProcess, SecureFile, Server}
+  alias RedisServerWrapper.{Cli, Config, Connection, OSProcess, SecureFile, Server}
 
   require Logger
 
@@ -53,6 +60,9 @@ defmodule RedisServerWrapper.Sentinel do
     :master_port,
     :bind,
     :control_host,
+    :master_connection,
+    :sentinel_connection,
+    :username,
     :password,
     :redis_cli_bin,
     :master_pid,
@@ -140,13 +150,17 @@ defmodule RedisServerWrapper.Sentinel do
       |> Config.control_host()
 
     password = Keyword.get(opts, :password)
+    username = Keyword.get(opts, :username)
     distribution = Keyword.get(opts, :distribution, :core)
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, 10_000)
     loadmodule = Keyword.get(opts, :loadmodule, [])
     managed = Keyword.get(opts, :managed, true)
 
-    with :ok <- Server.validate_distribution(distribution),
+    with :ok <- valid_port(:master_port, master_port),
+         :ok <- reject_unix_transport(opts),
+         {:ok, master_connection} <- build_connection(opts, control_host, master_port),
+         :ok <- Server.validate_distribution(distribution),
          redis_server_bin =
            Keyword.get_lazy(opts, :redis_server_bin, fn ->
              Server.default_server_bin(distribution)
@@ -154,7 +168,18 @@ defmodule RedisServerWrapper.Sentinel do
          node_opts = %{
            bind: bind,
            control_host: control_host,
+           username: username,
            password: password,
+           tls: master_connection.transport == :tls,
+           tls_cert_file: Keyword.get(opts, :tls_cert_file),
+           tls_key_file: Keyword.get(opts, :tls_key_file),
+           tls_ca_cert_file: Keyword.get(opts, :tls_ca_cert_file),
+           tls_ca_cert_dir: Keyword.get(opts, :tls_ca_cert_dir),
+           tls_auth_clients: Keyword.get(opts, :tls_auth_clients),
+           tls_client_cert_file: Keyword.get(opts, :tls_client_cert_file),
+           tls_client_key_file: Keyword.get(opts, :tls_client_key_file),
+           tls_server_name: Keyword.get(opts, :tls_server_name),
+           tls_insecure: Keyword.get(opts, :tls_insecure, false),
            distribution: distribution,
            redis_server_bin: redis_server_bin,
            redis_cli_bin: redis_cli_bin,
@@ -173,6 +198,7 @@ defmodule RedisServerWrapper.Sentinel do
            failover_timeout_ms: failover_timeout_ms,
            timeout: timeout
          },
+         :ok <- validate_server_connection_config(node_opts, master_port),
          :ok <- validate_options(validation_settings),
          {:ok, master_pid} <- start_master(master_port, node_opts),
          {:ok, replica_pids} <-
@@ -187,7 +213,18 @@ defmodule RedisServerWrapper.Sentinel do
              master_port: master_port,
              bind: bind,
              control_host: control_host,
+             username: username,
              password: password,
+             tls: master_connection.transport == :tls,
+             tls_cert_file: Keyword.get(opts, :tls_cert_file),
+             tls_key_file: Keyword.get(opts, :tls_key_file),
+             tls_ca_cert_file: Keyword.get(opts, :tls_ca_cert_file),
+             tls_ca_cert_dir: Keyword.get(opts, :tls_ca_cert_dir),
+             tls_auth_clients: Keyword.get(opts, :tls_auth_clients),
+             tls_client_cert_file: Keyword.get(opts, :tls_client_cert_file),
+             tls_client_key_file: Keyword.get(opts, :tls_client_key_file),
+             tls_server_name: Keyword.get(opts, :tls_server_name),
+             tls_insecure: Keyword.get(opts, :tls_insecure, false),
              quorum: quorum,
              down_after_ms: down_after_ms,
              failover_timeout_ms: failover_timeout_ms,
@@ -199,12 +236,16 @@ defmodule RedisServerWrapper.Sentinel do
       Process.sleep(2000)
 
       sentinel_ports = ports_from(sentinel_base_port, num_sentinels)
+      sentinel_connection = Connection.with_port(master_connection, sentinel_base_port)
 
       state = %__MODULE__{
         master_name: master_name,
         master_port: master_port,
         bind: bind,
         control_host: control_host,
+        master_connection: master_connection,
+        sentinel_connection: sentinel_connection,
+        username: username,
         password: password,
         redis_cli_bin: redis_cli_bin,
         master_pid: master_pid,
@@ -238,6 +279,8 @@ defmodule RedisServerWrapper.Sentinel do
       master_name: state.master_name,
       bind: state.bind,
       control_host: state.control_host,
+      master_connection: state.master_connection,
+      sentinel_connection: state.sentinel_connection,
       master_addr: format_addr(state.control_host, state.master_port),
       replicas: state.num_replicas,
       sentinels: state.num_sentinels,
@@ -250,7 +293,11 @@ defmodule RedisServerWrapper.Sentinel do
   def handle_call(:healthy?, _from, state) do
     result =
       Enum.any?(state.sentinel_ports, fn port ->
-        cli = Cli.new(bin: state.redis_cli_bin, host: state.control_host, port: port)
+        cli =
+          Cli.new(
+            bin: state.redis_cli_bin,
+            connection: Connection.with_port(state.sentinel_connection, port)
+          )
 
         case Cli.sentinel_master(cli, state.master_name) do
           {:ok, info} ->
@@ -273,7 +320,11 @@ defmodule RedisServerWrapper.Sentinel do
   def handle_call(:poke, _from, state) do
     result =
       Enum.find_value(state.sentinel_ports, {:error, :no_reachable_sentinel}, fn port ->
-        cli = Cli.new(bin: state.redis_cli_bin, host: state.control_host, port: port)
+        cli =
+          Cli.new(
+            bin: state.redis_cli_bin,
+            connection: Connection.with_port(state.sentinel_connection, port)
+          )
 
         case Cli.sentinel_master(cli, state.master_name) do
           {:ok, info} -> {:ok, info}
@@ -337,17 +388,18 @@ defmodule RedisServerWrapper.Sentinel do
 
   defp start_master(port, node_opts) do
     Server.start_link(
-      port: port,
-      bind: node_opts.bind,
-      control_host: node_opts.control_host,
-      password: node_opts.password,
-      distribution: node_opts.distribution,
-      redis_server_bin: node_opts.redis_server_bin,
-      redis_cli_bin: node_opts.redis_cli_bin,
-      timeout: node_opts.timeout,
-      managed: node_opts.managed,
-      loadmodule: node_opts.loadmodule,
-      save: :disabled
+      connection_server_opts(node_opts, port) ++
+        [
+          bind: node_opts.bind,
+          control_host: node_opts.control_host,
+          distribution: node_opts.distribution,
+          redis_server_bin: node_opts.redis_server_bin,
+          redis_cli_bin: node_opts.redis_cli_bin,
+          timeout: node_opts.timeout,
+          managed: node_opts.managed,
+          loadmodule: node_opts.loadmodule,
+          save: :disabled
+        ]
     )
   end
 
@@ -358,21 +410,22 @@ defmodule RedisServerWrapper.Sentinel do
       Enum.reduce_while(0..(count - 1), {:ok, []}, fn i, {:ok, acc} ->
         port = base_port + i
 
-        opts = [
-          port: port,
-          bind: node_opts.bind,
-          control_host: node_opts.control_host,
-          password: node_opts.password,
-          distribution: node_opts.distribution,
-          masterauth: node_opts.password,
-          replicaof: {node_opts.control_host, master_port},
-          redis_server_bin: node_opts.redis_server_bin,
-          redis_cli_bin: node_opts.redis_cli_bin,
-          timeout: node_opts.timeout,
-          managed: node_opts.managed,
-          loadmodule: node_opts.loadmodule,
-          save: :disabled
-        ]
+        opts =
+          connection_server_opts(node_opts, port) ++
+            [
+              bind: node_opts.bind,
+              control_host: node_opts.control_host,
+              distribution: node_opts.distribution,
+              masteruser: node_opts.username,
+              masterauth: node_opts.password,
+              replicaof: {node_opts.control_host, master_port},
+              redis_server_bin: node_opts.redis_server_bin,
+              redis_cli_bin: node_opts.redis_cli_bin,
+              timeout: node_opts.timeout,
+              managed: node_opts.managed,
+              loadmodule: node_opts.loadmodule,
+              save: :disabled
+            ]
 
         case Server.start_link(opts) do
           {:ok, pid} ->
@@ -432,8 +485,7 @@ defmodule RedisServerWrapper.Sentinel do
       conf_path,
       node_dir,
       opts.redis_cli_bin,
-      opts.control_host,
-      port,
+      sentinel_connection(opts, port),
       opts.timeout
     )
   end
@@ -444,7 +496,9 @@ defmodule RedisServerWrapper.Sentinel do
       control_host: control_host,
       master_name: master_name,
       master_port: master_port,
+      username: username,
       password: password,
+      tls: tls,
       quorum: quorum,
       down_after_ms: down_after_ms,
       failover_timeout_ms: failover_timeout_ms
@@ -452,28 +506,57 @@ defmodule RedisServerWrapper.Sentinel do
 
     listen_addresses = Config.new(bind: bind) |> Config.listen_addresses()
 
-    lines = [
-      Config.directive("port", [port]),
-      Config.directive("bind", listen_addresses),
-      Config.directive("daemonize", ["yes"]),
-      Config.directive("pidfile", [Path.join(dir, "sentinel.pid")]),
-      Config.directive("logfile", [Path.join(dir, "sentinel.log")]),
-      Config.directive("dir", [dir]),
-      Config.directive("sentinel", ["monitor", master_name, control_host, master_port, quorum]),
-      Config.directive("sentinel", ["down-after-milliseconds", master_name, down_after_ms]),
-      Config.directive("sentinel", ["failover-timeout", master_name, failover_timeout_ms]),
-      Config.directive("sentinel", ["parallel-syncs", master_name, 1])
-    ]
-
     lines =
-      if password do
-        lines ++ [Config.directive("sentinel", ["auth-pass", master_name, password])]
-      else
-        lines
-      end
+      [
+        Config.directive("port", [if(tls, do: 0, else: port)]),
+        Config.directive("bind", listen_addresses),
+        Config.directive("daemonize", ["yes"]),
+        Config.directive("pidfile", [Path.join(dir, "sentinel.pid")]),
+        Config.directive("logfile", [Path.join(dir, "sentinel.log")]),
+        Config.directive("dir", [dir]),
+        Config.directive("sentinel", ["monitor", master_name, control_host, master_port, quorum]),
+        Config.directive("sentinel", ["down-after-milliseconds", master_name, down_after_ms]),
+        Config.directive("sentinel", ["failover-timeout", master_name, failover_timeout_ms]),
+        Config.directive("sentinel", ["parallel-syncs", master_name, 1])
+      ] ++ sentinel_tls_lines(opts, port) ++ sentinel_auth_lines(username, password, master_name)
 
     Enum.join(lines, "\n") <> "\n"
   end
+
+  defp sentinel_tls_lines(%{tls: false}, _port), do: []
+
+  defp sentinel_tls_lines(opts, port) do
+    [
+      Config.directive("tls-port", [port]),
+      Config.directive("tls-cert-file", [opts.tls_cert_file]),
+      Config.directive("tls-key-file", [opts.tls_key_file])
+    ] ++
+      optional_directive("tls-ca-cert-file", opts.tls_ca_cert_file) ++
+      optional_directive("tls-ca-cert-dir", opts.tls_ca_cert_dir) ++
+      optional_directive("tls-auth-clients", opts.tls_auth_clients) ++
+      [Config.directive("tls-replication", ["yes"])]
+  end
+
+  defp sentinel_auth_lines(nil, nil, _master_name), do: []
+
+  defp sentinel_auth_lines(nil, password, master_name) do
+    [
+      Config.directive("requirepass", [password]),
+      Config.directive("sentinel", ["auth-pass", master_name, password])
+    ]
+  end
+
+  defp sentinel_auth_lines(username, password, master_name) do
+    [
+      Config.directive("user", ["default", "off"]),
+      Config.directive("user", [username, "on", ">#{password}", "~*", "&*", "+@all"]),
+      Config.directive("sentinel", ["auth-user", master_name, username]),
+      Config.directive("sentinel", ["auth-pass", master_name, password])
+    ]
+  end
+
+  defp optional_directive(_key, nil), do: []
+  defp optional_directive(key, value), do: [Config.directive(key, [value])]
 
   defp kill_pids(pids) do
     Enum.each(pids, fn pid ->
@@ -486,8 +569,7 @@ defmodule RedisServerWrapper.Sentinel do
          conf_path,
          node_dir,
          redis_cli_bin,
-         bind,
-         port,
+         connection,
          timeout
        ) do
     # Sentinel rewrites its configuration as topology state changes. Launch it
@@ -505,7 +587,7 @@ defmodule RedisServerWrapper.Sentinel do
     case System.cmd("/bin/sh", command_args, stderr_to_stdout: true) do
       {_output, 0} ->
         # Wait for sentinel to be ready
-        cli = Cli.new(bin: redis_cli_bin, host: bind, port: port)
+        cli = Cli.new(bin: redis_cli_bin, connection: connection)
 
         case Cli.wait_for_ready(cli, timeout) do
           :ok ->
@@ -514,15 +596,90 @@ defmodule RedisServerWrapper.Sentinel do
             {:ok, pid}
 
           {:error, :timeout} ->
-            {:error, {:sentinel_start_timeout, port}}
+            {:error, {:sentinel_start_timeout, connection.port}}
 
           {:error, {:unexpected_reply, reply}} ->
-            {:error, {:sentinel_port_in_use, port, reply}}
+            {:error, {:sentinel_port_in_use, connection.port, reply}}
         end
 
       {output, code} ->
-        {:error, {:sentinel_start_failed, port, code, output}}
+        {:error, {:sentinel_start_failed, connection.port, code, output}}
     end
+  end
+
+  defp connection_server_opts(%{tls: false} = opts, port) do
+    [
+      port: port,
+      username: opts.username,
+      password: opts.password
+    ]
+  end
+
+  defp connection_server_opts(%{tls: true} = opts, port) do
+    [
+      port: 0,
+      tls_port: port,
+      username: opts.username,
+      password: opts.password,
+      tls_cert_file: opts.tls_cert_file,
+      tls_key_file: opts.tls_key_file,
+      tls_ca_cert_file: opts.tls_ca_cert_file,
+      tls_ca_cert_dir: opts.tls_ca_cert_dir,
+      tls_auth_clients: opts.tls_auth_clients,
+      tls_client_cert_file: opts.tls_client_cert_file,
+      tls_client_key_file: opts.tls_client_key_file,
+      tls_server_name: opts.tls_server_name,
+      tls_insecure: opts.tls_insecure,
+      tls_replication: true
+    ]
+  end
+
+  defp build_connection(opts, host, port) do
+    transport = if Keyword.get(opts, :tls, false), do: :tls, else: :tcp
+
+    connection_opts = [
+      transport: transport,
+      host: host,
+      port: port,
+      username: Keyword.get(opts, :username),
+      password: Keyword.get(opts, :password),
+      tls_ca_cert_file: Keyword.get(opts, :tls_ca_cert_file),
+      tls_ca_cert_dir: Keyword.get(opts, :tls_ca_cert_dir),
+      tls_client_cert_file: Keyword.get(opts, :tls_client_cert_file),
+      tls_client_key_file: Keyword.get(opts, :tls_client_key_file),
+      tls_server_name: Keyword.get(opts, :tls_server_name),
+      tls_insecure: Keyword.get(opts, :tls_insecure, false)
+    ]
+
+    {:ok, Connection.new(connection_opts)}
+  rescue
+    error in ArgumentError -> {:error, {:invalid_connection, Exception.message(error)}}
+  end
+
+  defp sentinel_connection(opts, port) do
+    {:ok, connection} = build_connection(Map.to_list(opts), opts.control_host, port)
+    connection
+  end
+
+  defp reject_unix_transport(opts) do
+    if Keyword.get(opts, :unixsocket) || Keyword.get(opts, :transport) == :unix do
+      {:error, {:unsupported_transport, :sentinel, :unix}}
+    else
+      :ok
+    end
+  end
+
+  defp validate_server_connection_config(node_opts, port) do
+    _config =
+      Config.new(
+        connection_server_opts(node_opts, port) ++
+          [bind: node_opts.bind, control_host: node_opts.control_host]
+      )
+
+    :ok
+  rescue
+    error in ArgumentError ->
+      {:error, {:invalid_connection_config, Exception.message(error)}}
   end
 
   defp read_pidfile(path) do

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -18,6 +18,15 @@ defmodule RedisServerWrapper.Server do
 
     * `:redis_server_bin` - path to redis-server binary (default: "redis-server")
     * `:redis_cli_bin` - path to redis-cli binary (default: "redis-cli")
+    * `:username` - optional named ACL user paired with `:password`
+    * `:port` - plaintext TCP port; use `0` to disable plaintext TCP
+    * `:unixsocket` - Unix socket path used when TCP and TLS are disabled
+    * `:tls_port` - TLS listener and lifecycle connection port
+    * `:tls_cert_file`, `:tls_key_file` - Redis TLS server identity
+    * `:tls_ca_cert_file` or `:tls_ca_cert_dir` - trusted CA for Redis and redis-cli
+    * `:tls_client_cert_file`, `:tls_client_key_file` - optional redis-cli identity
+    * `:tls_server_name` - optional redis-cli SNI name
+    * `:tls_insecure` - explicitly disable redis-cli certificate verification
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`.
       Only explicit `:legacy_stack` selection enables legacy Stack module
       discovery; caller-provided `:loadmodule` entries always remain explicit.
@@ -41,7 +50,7 @@ defmodule RedisServerWrapper.Server do
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Config, OSProcess, SecureFile}
+  alias RedisServerWrapper.{Cli, Config, Connection, OSProcess, SecureFile}
 
   require Logger
 
@@ -114,7 +123,7 @@ defmodule RedisServerWrapper.Server do
   @spec run(GenServer.server(), [String.t()]) :: {:ok, String.t()} | {:error, String.t()}
   def run(server, args), do: GenServer.call(server, {:run, args})
 
-  @doc "Returns connection info: host, port, password, pid, node_dir."
+  @doc "Returns connection and process information."
   @spec info(GenServer.server()) :: map()
   def info(server), do: GenServer.call(server, :info)
 
@@ -168,26 +177,26 @@ defmodule RedisServerWrapper.Server do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     managed = Keyword.get(opts, :managed, true)
 
+    config_opts =
+      Keyword.drop(opts, [
+        :redis_server_bin,
+        :redis_cli_bin,
+        :distribution,
+        :name,
+        :timeout,
+        :managed
+      ])
+
     # Validate binaries and the managed backend selection
     with :ok <- validate_distribution(distribution),
          redis_server_bin =
            Keyword.get_lazy(opts, :redis_server_bin, fn -> default_server_bin(distribution) end),
          :ok <- validate_managed(managed),
          :ok <- check_binary(redis_server_bin),
-         :ok <- check_binary(redis_cli_bin) do
-      config_opts =
-        Keyword.drop(opts, [
-          :redis_server_bin,
-          :redis_cli_bin,
-          :distribution,
-          :name,
-          :timeout,
-          :managed
-        ])
-
-      config = Config.new(config_opts)
-
-      case start_redis_server(
+         :ok <- check_binary(redis_cli_bin),
+         {:ok, config} <- build_config(config_opts),
+         {:ok, state} <-
+           start_redis_server(
              config,
              redis_server_bin,
              redis_cli_bin,
@@ -195,12 +204,7 @@ defmodule RedisServerWrapper.Server do
              managed,
              distribution
            ) do
-        {:ok, state} ->
-          {:ok, state}
-
-        {:error, reason} ->
-          {:stop, reason}
-      end
+      {:ok, state}
     else
       {:error, reason} -> {:stop, reason}
     end
@@ -220,11 +224,17 @@ defmodule RedisServerWrapper.Server do
   end
 
   def handle_call(:info, _from, state) do
+    connection = state.cli.connection
+
     info = %{
       host: Config.control_host(state.config),
       bind: state.config.bind,
       port: state.config.port,
+      tls_port: state.config.tls_port,
+      unixsocket: state.config.unixsocket,
+      username: state.config.username,
       password: state.config.password,
+      connection: connection,
       pid: state.pid,
       node_dir: state.node_dir,
       distribution: state.distribution,
@@ -290,7 +300,8 @@ defmodule RedisServerWrapper.Server do
     # until the whole redis-server process group is confirmed dead (SIGTERM then
     # SIGKILL). No SHUTDOWN/Port.close/SIGKILL ladder needed on this path.
     Logger.debug(
-      "RedisServerWrapper.Server terminating, stopping Forcola.Daemon for port #{state.config.port}"
+      "RedisServerWrapper.Server terminating, stopping Forcola.Daemon for " <>
+        Connection.label(state.cli.connection)
     )
 
     stop_daemon(daemon)
@@ -299,7 +310,8 @@ defmodule RedisServerWrapper.Server do
 
   def terminate(_reason, state) do
     Logger.debug(
-      "RedisServerWrapper.Server terminating, sending SHUTDOWN NOSAVE to port #{state.config.port}"
+      "RedisServerWrapper.Server terminating, sending SHUTDOWN NOSAVE to " <>
+        Connection.label(state.cli.connection)
     )
 
     shutdown_if_owned(state)
@@ -315,9 +327,14 @@ defmodule RedisServerWrapper.Server do
 
     force_kill_pid =
       cond do
-        managed_pid_owned -> state.pid
-        is_nil(state.port_ref) and pid_owns_port?(state.pid, state.config.port) -> state.pid
-        true -> nil
+        managed_pid_owned ->
+          state.pid
+
+        is_nil(state.port_ref) and pid_owns_listener?(state.pid, state.cli.connection) ->
+          state.pid
+
+        true ->
+          nil
       end
 
     # Force kill only when ownership was re-established immediately before the
@@ -365,13 +382,14 @@ defmodule RedisServerWrapper.Server do
 
   # Port-based: redis-server runs in the foreground, tied to the BEAM.
   defp start_managed(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
-    with :ok <- check_port_available(Config.control_host(config), config.port) do
+    with :ok <- check_endpoints_available(config) do
       do_start_managed(config, redis_server_bin, redis_cli_bin, timeout, distribution)
     end
   end
 
   defp do_start_managed(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
-    node_dir = make_node_dir(config.port)
+    connection = Config.connection(config)
+    node_dir = make_node_dir(Connection.id(connection))
 
     config = %{
       config
@@ -400,9 +418,7 @@ defmodule RedisServerWrapper.Server do
     cli =
       Cli.new(
         bin: redis_cli_bin,
-        host: Config.control_host(config),
-        port: config.port,
-        password: config.password
+        connection: Config.connection(config)
       )
 
     case Cli.wait_for_ready(cli, timeout) do
@@ -428,11 +444,11 @@ defmodule RedisServerWrapper.Server do
 
       {:error, :timeout} ->
         safe_port_close(port_ref)
-        {:error, {:server_start_timeout, config.port}}
+        {:error, server_start_timeout(cli.connection)}
 
       {:error, {:unexpected_reply, reply}} ->
         safe_port_close(port_ref)
-        {:error, {:port_in_use, config.port, reply}}
+        {:error, endpoint_in_use(cli.connection, reply)}
     end
   end
 
@@ -449,7 +465,7 @@ defmodule RedisServerWrapper.Server do
          distribution
        ) do
     if forcola_available?() do
-      with :ok <- check_port_available(Config.control_host(config), config.port) do
+      with :ok <- check_endpoints_available(config) do
         do_start_managed_forcola(
           config,
           redis_server_bin,
@@ -470,7 +486,8 @@ defmodule RedisServerWrapper.Server do
          timeout,
          distribution
        ) do
-    node_dir = make_node_dir(config.port)
+    connection = Config.connection(config)
+    node_dir = make_node_dir(Connection.id(connection))
 
     config = %{
       config
@@ -491,9 +508,7 @@ defmodule RedisServerWrapper.Server do
     cli =
       Cli.new(
         bin: redis_cli_bin,
-        host: Config.control_host(config),
-        port: config.port,
-        password: config.password
+        connection: Config.connection(config)
       )
 
     daemon_opts = [
@@ -521,10 +536,10 @@ defmodule RedisServerWrapper.Server do
         {:ok, state}
 
       {:error, :ready_timeout} ->
-        {:error, {:server_start_timeout, config.port}}
+        {:error, server_start_timeout(cli.connection)}
 
       {:error, {:exited_before_ready, reason}} ->
-        {:error, {:server_start_failed, config.port, reason}}
+        {:error, {:server_start_failed, endpoint_value(cli.connection), reason}}
 
       {:error, reason} ->
         {:error, reason}
@@ -544,13 +559,14 @@ defmodule RedisServerWrapper.Server do
   # wanted instances. If the port is held, check_port_available returns
   # {:error, {:port_in_use, ...}} and the caller decides what to do.
   defp start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
-    with :ok <- check_port_available(Config.control_host(config), config.port) do
+    with :ok <- check_endpoints_available(config) do
       do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout, distribution)
     end
   end
 
   defp do_start_unmanaged(config, redis_server_bin, redis_cli_bin, timeout, distribution) do
-    node_dir = make_node_dir(config.port)
+    connection = Config.connection(config)
+    node_dir = make_node_dir(Connection.id(connection))
     pidfile_path = Path.join(node_dir, "redis.pid")
 
     config = %{
@@ -574,9 +590,7 @@ defmodule RedisServerWrapper.Server do
         cli =
           Cli.new(
             bin: redis_cli_bin,
-            host: Config.control_host(config),
-            port: config.port,
-            password: config.password
+            connection: Config.connection(config)
           )
 
         case Cli.wait_for_ready(cli, timeout) do
@@ -596,16 +610,47 @@ defmodule RedisServerWrapper.Server do
             {:ok, state}
 
           {:error, :timeout} ->
-            {:error, {:server_start_timeout, config.port}}
+            {:error, server_start_timeout(cli.connection)}
 
           {:error, {:unexpected_reply, reply}} ->
-            {:error, {:port_in_use, config.port, reply}}
+            {:error, endpoint_in_use(cli.connection, reply)}
         end
 
       {output, code} ->
-        {:error, {:server_start_failed, config.port, code, output}}
+        {:error, {:server_start_failed, endpoint_value(connection), code, output}}
     end
   end
+
+  defp check_endpoints_available(config) do
+    endpoints =
+      []
+      |> maybe_add_tcp_endpoint(Config.control_host(config), config.port)
+      |> maybe_add_tcp_endpoint(Config.control_host(config), config.tls_port)
+      |> maybe_add_unix_endpoint(config.unixsocket)
+      |> Enum.uniq()
+
+    Enum.reduce_while(endpoints, :ok, fn
+      {:tcp, host, port}, :ok ->
+        case check_port_available(host, port) do
+          :ok -> {:cont, :ok}
+          {:error, _reason} = error -> {:halt, error}
+        end
+
+      {:unix, path}, :ok ->
+        if File.exists?(path) do
+          {:halt, {:error, {:unix_socket_in_use, path}}}
+        else
+          {:cont, :ok}
+        end
+    end)
+  end
+
+  defp maybe_add_tcp_endpoint(endpoints, _host, nil), do: endpoints
+  defp maybe_add_tcp_endpoint(endpoints, _host, 0), do: endpoints
+  defp maybe_add_tcp_endpoint(endpoints, host, port), do: [{:tcp, host, port} | endpoints]
+
+  defp maybe_add_unix_endpoint(endpoints, nil), do: endpoints
+  defp maybe_add_unix_endpoint(endpoints, path), do: [{:unix, path} | endpoints]
 
   # Pre-flight: try to bind the target (bind, port) ourselves to detect the
   # common case where another process (another redis-server, macOS AirPlay,
@@ -640,12 +685,12 @@ defmodule RedisServerWrapper.Server do
     end
   end
 
-  defp make_node_dir(port) do
+  defp make_node_dir(endpoint_id) do
     dir =
       Path.join([
         System.tmp_dir!(),
         "redis-server-wrapper",
-        "node-#{port}"
+        "node-#{endpoint_id}"
       ])
 
     File.rm_rf!(dir)
@@ -686,7 +731,7 @@ defmodule RedisServerWrapper.Server do
     if managed_port_owns_pid?(state.port_ref, state.pid) do
       run_shutdown(state)
     else
-      shutdown_if_listener_owned(state, OSProcess.pids_on_port(state.config.port))
+      shutdown_if_listener_owned(state, pids_on_listener(state.cli.connection))
     end
   end
 
@@ -695,7 +740,7 @@ defmodule RedisServerWrapper.Server do
       run_shutdown(state)
     else
       Logger.warning(
-        "Skipping Redis shutdown on port #{state.config.port}: " <>
+        "Skipping Redis shutdown on #{Connection.label(state.cli.connection)}: " <>
           "tracked PID #{state.pid} no longer owns the listener"
       )
     end
@@ -704,7 +749,7 @@ defmodule RedisServerWrapper.Server do
   defp shutdown_if_listener_owned(state, {:error, {:executable_not_found, "lsof"}}) do
     Logger.warning(
       "lsof is unavailable; skipping ownership-sensitive Redis shutdown " <>
-        "on port #{state.config.port}"
+        "on #{Connection.label(state.cli.connection)}"
     )
   end
 
@@ -722,14 +767,35 @@ defmodule RedisServerWrapper.Server do
 
   defp managed_port_owns_pid?(_port_ref, _pid), do: false
 
-  defp pid_owns_port?(pid, port) when is_integer(pid) do
-    case OSProcess.pids_on_port(port) do
+  defp pid_owns_listener?(pid, connection) when is_integer(pid) do
+    case pids_on_listener(connection) do
       {:ok, pids} -> pid in pids
       {:error, _reason} -> false
     end
   end
 
-  defp pid_owns_port?(_pid, _port), do: false
+  defp pid_owns_listener?(_pid, _connection), do: false
+
+  defp pids_on_listener(%Connection{transport: :unix, socket: socket}) do
+    OSProcess.pids_on_socket(socket)
+  end
+
+  defp pids_on_listener(%Connection{port: port}), do: OSProcess.pids_on_port(port)
+
+  defp server_start_timeout(%Connection{transport: :unix, socket: socket}) do
+    {:server_start_timeout, {:unix, socket}}
+  end
+
+  defp server_start_timeout(%Connection{port: port}), do: {:server_start_timeout, port}
+
+  defp endpoint_in_use(%Connection{transport: :unix, socket: socket}, reply) do
+    {:unix_socket_in_use, socket, reply}
+  end
+
+  defp endpoint_in_use(%Connection{port: port}, reply), do: {:port_in_use, port, reply}
+
+  defp endpoint_value(%Connection{transport: :unix, socket: socket}), do: {:unix, socket}
+  defp endpoint_value(%Connection{port: port}), do: port
 
   defp warn_if_signal_unavailable(
          {:error, {:executable_not_found, "kill"}},
@@ -777,6 +843,12 @@ defmodule RedisServerWrapper.Server do
       nil -> {:error, {:binary_not_found, bin}}
       _path -> :ok
     end
+  end
+
+  defp build_config(opts) do
+    {:ok, Config.new(opts)}
+  rescue
+    error in ArgumentError -> {:error, {:invalid_config, Exception.message(error)}}
   end
 
   defp extract_gen_opts(opts) do

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -1,7 +1,20 @@
 defmodule RedisServerWrapperTest do
   use ExUnit.Case, async: false
 
-  alias RedisServerWrapper.{Cli, Cluster, Config, Manager, Sentinel, Server}
+  alias RedisServerWrapper.{Cli, Cluster, Config, Connection, Manager, Sentinel, Server}
+
+  setup_all do
+    tls_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "redis-server-wrapper-tls-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(tls_dir)
+    tls = generate_tls_files!(tls_dir)
+    on_exit(fn -> File.rm_rf!(tls_dir) end)
+    {:ok, tls: tls}
+  end
 
   defp wait_until(fun, retries \\ 10, delay \\ 1000) do
     if fun.() do
@@ -175,7 +188,8 @@ defmodule RedisServerWrapperTest do
           tls_port: 6380,
           tls_cert_file: "/path/cert.pem",
           tls_key_file: "/path/key.pem",
-          tls_ca_cert_file: "/path/ca.pem"
+          tls_ca_cert_file: "/path/ca.pem",
+          tls_auth_clients: "no"
         )
 
       output = Config.to_config_string(config)
@@ -183,6 +197,39 @@ defmodule RedisServerWrapperTest do
       assert output =~ "tls-cert-file /path/cert.pem"
       assert output =~ "tls-key-file /path/key.pem"
       assert output =~ "tls-ca-cert-file /path/ca.pem"
+      assert output =~ "tls-auth-clients no"
+    end
+
+    test "named ACL auth and operational endpoint selection" do
+      acl = Config.new(username: "app user", password: "secret value")
+      output = Config.to_config_string(acl)
+
+      assert output =~ "user default off"
+      assert output =~ ~s(user "app user" on ">secret value" ~* &* +@all)
+      refute output =~ "requirepass"
+
+      assert %Connection{
+               transport: :tcp,
+               username: "app user",
+               password: "secret value"
+             } = Config.connection(acl)
+
+      unix = Config.new(port: 0, unixsocket: "/tmp/redis wrapper.sock")
+
+      assert %Connection{transport: :unix, socket: "/tmp/redis wrapper.sock"} =
+               Config.connection(unix)
+
+      assert_raise ArgumentError, ~r/:username requires/, fn ->
+        Config.new(username: "app")
+      end
+
+      assert_raise ArgumentError, ~r/at least one/, fn ->
+        Config.new(port: 0)
+      end
+
+      assert_raise ArgumentError, ~r/:unixsocket must be at most 103 bytes/, fn ->
+        Config.new(port: 0, unixsocket: "/" <> String.duplicate("a", 104))
+      end
     end
   end
 
@@ -237,6 +284,84 @@ defmodule RedisServerWrapperTest do
       Process.sleep(500)
     end
 
+    test "start over a Unix socket with TCP disabled" do
+      socket =
+        Path.join(
+          System.tmp_dir!(),
+          "redis-server-wrapper-#{System.unique_integer([:positive])}.sock"
+        )
+
+      {:ok, server} =
+        Server.start_link(
+          port: 0,
+          unixsocket: socket,
+          unixsocketperm: "700"
+        )
+
+      try do
+        assert Server.ping(server)
+        assert {:ok, "OK"} = Server.run(server, ["SET", "unix-key", "unix-value"])
+        assert {:ok, "unix-value"} = Server.run(server, ["GET", "unix-key"])
+        assert %Connection{transport: :unix, socket: ^socket} = Server.cli(server).connection
+      after
+        Server.stop(server)
+      end
+
+      refute File.exists?(socket)
+    end
+
+    test "start with named ACL credentials" do
+      {:ok, server} =
+        Server.start_link(
+          port: 6407,
+          username: "wrapper-app",
+          password: "acl secret"
+        )
+
+      try do
+        assert Server.ping(server)
+        assert {:ok, "OK"} = Server.run(server, ["SET", "acl-key", "acl-value"])
+        assert {:ok, "acl-value"} = Server.run(server, ["GET", "acl-key"])
+
+        assert %Connection{username: "wrapper-app", password: "acl secret"} =
+                 Server.cli(server).connection
+      after
+        Server.stop(server)
+      end
+    end
+
+    test "start TLS-only with CA verification, SNI, and client authentication", %{tls: tls} do
+      {:ok, server} =
+        Server.start_link(
+          port: 0,
+          tls_port: 6408,
+          tls_cert_file: tls.cert,
+          tls_key_file: tls.key,
+          tls_ca_cert_file: tls.ca,
+          tls_auth_clients: "yes",
+          tls_client_cert_file: tls.cert,
+          tls_client_key_file: tls.key,
+          tls_server_name: "localhost",
+          username: "tls-app",
+          password: "tls secret"
+        )
+
+      try do
+        assert Server.ping(server)
+        assert {:ok, "OK"} = Server.run(server, ["SET", "tls-key", "tls-value"])
+        assert {:ok, "tls-value"} = Server.run(server, ["GET", "tls-key"])
+
+        assert %Connection{
+                 transport: :tls,
+                 port: 6408,
+                 username: "tls-app",
+                 tls_server_name: "localhost"
+               } = Server.cli(server).connection
+      after
+        Server.stop(server)
+      end
+    end
+
     test "multiple listen addresses use an explicit control host" do
       {:ok, server} =
         Server.start_link(
@@ -249,7 +374,7 @@ defmodule RedisServerWrapperTest do
         assert Server.ping(server)
         assert Server.info(server).bind == ["127.0.0.1", "::1"]
         assert Server.info(server).host == "127.0.0.1"
-        assert Server.cli(server).host == "127.0.0.1"
+        assert Server.cli(server).connection.host == "127.0.0.1"
       after
         Server.stop(server)
       end
@@ -514,6 +639,44 @@ defmodule RedisServerWrapperTest do
 
       assert :ok = Manager.stop(instance.name)
       assert wait_until(fn -> not Cli.ping(cli) end, 5, 200)
+    end
+
+    test "Unix-socket instances persist their connection and stop cleanly" do
+      socket =
+        Path.join(
+          System.tmp_dir!(),
+          "rsw-manager-#{System.unique_integer([:positive])}.sock"
+        )
+
+      assert {:ok, instance} =
+               Manager.start_basic(
+                 name: "unix-basic",
+                 port: 0,
+                 unixsocket: socket,
+                 unixsocketperm: "700",
+                 username: "manager-app",
+                 password: "manager secret"
+               )
+
+      cli = Cli.new(connection: instance.connection)
+
+      try do
+        assert instance.ports == []
+        assert instance.url == "unix://#{URI.encode(socket)}"
+        assert instance.connection.transport == :unix
+        assert Cli.ping(cli)
+
+        assert {:ok, credentials} = Manager.credentials(instance.name)
+        assert credentials.username == "manager-app"
+        assert credentials.url == instance.url
+
+        assert :ok = Manager.stop(instance.name)
+        assert wait_until(fn -> not Cli.ping(cli) end, 5, 200)
+        refute File.exists?(socket)
+      after
+        if Cli.ping(cli), do: Manager.stop(instance.name)
+        File.rm(socket)
+      end
     end
 
     test "credentials stay out of default output and state is private", %{state_file: state_file} do
@@ -929,6 +1092,32 @@ defmodule RedisServerWrapperTest do
       Cluster.stop(cluster)
       Process.sleep(1000)
     end
+
+    @tag timeout: 30_000
+    test "TLS-only cluster forms and serves commands", %{tls: tls} do
+      {:ok, cluster} =
+        Cluster.start_link(
+          masters: 3,
+          base_port: 7120,
+          tls: true,
+          tls_cert_file: tls.cert,
+          tls_key_file: tls.key,
+          tls_ca_cert_file: tls.ca,
+          tls_auth_clients: "no",
+          tls_server_name: "localhost",
+          username: "cluster-app",
+          password: "cluster secret"
+        )
+
+      try do
+        assert Cluster.all_alive?(cluster)
+        assert wait_until(fn -> Cluster.healthy?(cluster) end)
+        assert {:ok, "PONG"} = Cluster.run(cluster, ["PING"])
+        assert Cluster.info(cluster).connection.transport == :tls
+      after
+        Cluster.stop(cluster)
+      end
+    end
   end
 
   describe "Sentinel" do
@@ -1011,6 +1200,122 @@ defmodule RedisServerWrapperTest do
 
       Sentinel.stop(sentinel)
       Process.sleep(1000)
+    end
+
+    @tag timeout: 30_000
+    test "TLS-only Sentinel uses named ACL auth for monitoring and replication", %{tls: tls} do
+      {:ok, sentinel} =
+        Sentinel.start_link(
+          master_port: 6520,
+          replicas: 1,
+          replica_base_port: 6521,
+          sentinels: 1,
+          sentinel_base_port: 26_520,
+          quorum: 1,
+          tls: true,
+          tls_cert_file: tls.cert,
+          tls_key_file: tls.key,
+          tls_ca_cert_file: tls.ca,
+          tls_auth_clients: "no",
+          tls_server_name: "localhost",
+          username: "sentinel-app",
+          password: "sentinel secret"
+        )
+
+      try do
+        assert wait_until(fn -> Sentinel.healthy?(sentinel) end)
+        assert {:ok, master_info} = Sentinel.poke(sentinel)
+        assert master_info["flags"] == "master"
+        assert Sentinel.info(sentinel).master_connection.transport == :tls
+      after
+        Sentinel.stop(sentinel)
+      end
+    end
+  end
+
+  defp generate_tls_files!(dir) do
+    openssl =
+      System.find_executable("openssl") ||
+        raise "openssl is required for Redis TLS integration tests"
+
+    ca_key = Path.join(dir, "ca.key")
+    ca = Path.join(dir, "ca.crt")
+    key = Path.join(dir, "server.key")
+    csr = Path.join(dir, "server.csr")
+    cert = Path.join(dir, "server.crt")
+    extensions = Path.join(dir, "server.ext")
+
+    openssl!(
+      openssl,
+      [
+        "req",
+        "-x509",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-sha256",
+        "-days",
+        "2",
+        "-subj",
+        "/CN=RedisServerWrapper Test CA",
+        "-keyout",
+        ca_key,
+        "-out",
+        ca
+      ]
+    )
+
+    openssl!(
+      openssl,
+      [
+        "req",
+        "-newkey",
+        "rsa:2048",
+        "-nodes",
+        "-sha256",
+        "-subj",
+        "/CN=localhost",
+        "-keyout",
+        key,
+        "-out",
+        csr
+      ]
+    )
+
+    File.write!(
+      extensions,
+      "subjectAltName=DNS:localhost,IP:127.0.0.1\nextendedKeyUsage=serverAuth,clientAuth\n"
+    )
+
+    openssl!(
+      openssl,
+      [
+        "x509",
+        "-req",
+        "-sha256",
+        "-days",
+        "2",
+        "-in",
+        csr,
+        "-CA",
+        ca,
+        "-CAkey",
+        ca_key,
+        "-CAcreateserial",
+        "-extfile",
+        extensions,
+        "-out",
+        cert
+      ]
+    )
+
+    %{ca: ca, cert: cert, key: key}
+  end
+
+  defp openssl!(openssl, args) do
+    case System.cmd(openssl, args, stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, status} -> raise "openssl failed (#{status}): #{output}"
     end
   end
 

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -1,7 +1,7 @@
 defmodule RedisServerWrapperUnitTest do
   use ExUnit.Case, async: false
 
-  alias RedisServerWrapper.{Cli, Cluster, OSProcess, SecureFile, Sentinel, Server}
+  alias RedisServerWrapper.{Cli, Cluster, Connection, OSProcess, SecureFile, Sentinel, Server}
 
   setup do
     fixture_dir =
@@ -80,7 +80,7 @@ defmodule RedisServerWrapperUnitTest do
   end
 
   test "CLI runs commands, assembles connection options, and raises on errors", %{cli_bin: bin} do
-    assert %Cli{host: "127.0.0.1", port: 6379} = Cli.new()
+    assert %Cli{connection: %Connection{host: "127.0.0.1", port: 6379}} = Cli.new()
 
     cli = Cli.new(bin: bin, host: "ready", port: 6380, password: "secret", tls: true)
 
@@ -97,10 +97,68 @@ defmodule RedisServerWrapperUnitTest do
 
     assert Cli.run!(cli, ["ECHO"]) =~ "--tls ECHO"
     assert Cli.ping(cli)
+    assert :ok = Cli.shutdown(cli)
 
     assert {:error, "failure"} = Cli.run(cli, ["FAIL"])
     assert_raise RuntimeError, ~r/redis-cli error: failure/, fn -> Cli.run!(cli, ["FAIL"]) end
-    refute Cli.ping(%{cli | host: "error"})
+
+    error_cli = %{cli | connection: %{cli.connection | host: "error"}}
+    refute Cli.ping(error_cli)
+  end
+
+  test "Connection assembles Unix, ACL, and complete TLS client arguments" do
+    unix =
+      Connection.new(
+        transport: :unix,
+        socket: "/tmp/redis wrapper.sock",
+        username: "app user",
+        password: "secret"
+      )
+
+    assert Connection.cli_args(unix) ==
+             ["-s", "/tmp/redis wrapper.sock", "--user", "app user"]
+
+    assert Connection.cli_env(unix) == [{"REDISCLI_AUTH", "secret"}]
+    assert Connection.url(unix) == "unix:///tmp/redis%20wrapper.sock"
+
+    tls =
+      Connection.new(
+        transport: :tls,
+        host: "::1",
+        port: 6380,
+        username: "app",
+        password: "secret",
+        tls_ca_cert_file: "/certs/ca.pem",
+        tls_client_cert_file: "/certs/client.pem",
+        tls_client_key_file: "/certs/client.key",
+        tls_server_name: "redis.test",
+        tls_insecure: true
+      )
+
+    assert Connection.cli_args(tls) == [
+             "-h",
+             "::1",
+             "-p",
+             "6380",
+             "--user",
+             "app",
+             "--tls",
+             "--cacert",
+             "/certs/ca.pem",
+             "--cert",
+             "/certs/client.pem",
+             "--key",
+             "/certs/client.key",
+             "--sni",
+             "redis.test",
+             "--insecure"
+           ]
+
+    assert Connection.url(tls) == "rediss://app:secret@[::1]:6380"
+
+    assert_raise ArgumentError, ~r/must be set together/, fn ->
+      Connection.new(transport: :tls, tls_client_cert_file: "/certs/client.pem")
+    end
   end
 
   test "CLI readiness distinguishes ready, transient, failed, and unexpected peers", %{
@@ -214,6 +272,14 @@ defmodule RedisServerWrapperUnitTest do
     assert {:error, {:invalid_distribution, :unknown}} =
              Server.start(distribution: :unknown)
 
+    assert {:error, {:invalid_config, endpoint_error}} = Server.start(port: 0)
+    assert endpoint_error =~ "at least one of :port, :tls_port, or :unixsocket"
+
+    assert {:error, {:invalid_config, tls_error}} =
+             Server.start(port: 0, tls_port: 6442)
+
+    assert tls_error =~ ":tls_cert_file is required"
+
     assert {:error, {:server_start_failed, 6440, _status, _output}} =
              Server.start(port: 6440, managed: false, redis_server_bin: "false")
 
@@ -305,6 +371,7 @@ defmodule RedisServerWrapperUnitTest do
     assert OSProcess.orphaned?(123)
     refute OSProcess.orphaned?(999)
     assert {:ok, [123, 456]} = OSProcess.pids_on_port(6490)
+    assert {:ok, [123, 456]} = OSProcess.pids_on_socket("/tmp/redis.sock")
   end
 
   test "missing kill and lsof do not crash process helpers or normal teardown", %{
@@ -325,6 +392,10 @@ defmodule RedisServerWrapperUnitTest do
     refute OSProcess.available?("lsof")
     assert {:error, {:executable_not_found, "kill"}} = OSProcess.signal(1, :term)
     assert {:error, {:executable_not_found, "lsof"}} = OSProcess.pids_on_port(6490)
+
+    assert {:error, {:executable_not_found, "lsof"}} =
+             OSProcess.pids_on_socket("/tmp/redis.sock")
+
     assert is_boolean(OSProcess.alive?(String.to_integer(System.pid())))
     assert is_boolean(OSProcess.orphaned?(String.to_integer(System.pid())))
 
@@ -359,6 +430,12 @@ defmodule RedisServerWrapperUnitTest do
     assert {:error, {:invalid_option, :timeout, 0}} = Cluster.start(timeout: 0)
     assert {:error, {:invalid_option, :base_port, 0}} = Cluster.start(base_port: 0)
 
+    assert {:error, {:unsupported_transport, :cluster, :unix}} =
+             Cluster.start(unixsocket: "/tmp/cluster.sock")
+
+    assert {:error, {:invalid_connection_config, tls_error}} = Cluster.start(tls: true)
+    assert tls_error =~ ":tls_cert_file is required"
+
     assert {:error, {:invalid_port_range, :cluster_nodes, 65_535, 65_536}} =
              Cluster.start(masters: 2, base_port: 65_535)
 
@@ -379,6 +456,12 @@ defmodule RedisServerWrapperUnitTest do
     assert {:error, {:invalid_quorum, 4, 3}} = Sentinel.start(quorum: 4)
     assert {:error, {:invalid_option, :timeout, 0}} = Sentinel.start(timeout: 0)
     assert {:error, {:invalid_option, :master_port, "bad"}} = Sentinel.start(master_port: "bad")
+
+    assert {:error, {:unsupported_transport, :sentinel, :unix}} =
+             Sentinel.start(unixsocket: "/tmp/sentinel.sock")
+
+    assert {:error, {:invalid_connection_config, tls_error}} = Sentinel.start(tls: true)
+    assert tls_error =~ ":tls_cert_file is required"
 
     assert {:error, {:invalid_option, :sentinel_base_port, 0}} =
              Sentinel.start(sentinel_base_port: 0)


### PR DESCRIPTION
Closes #54

## Summary

- add `RedisServerWrapper.Connection` as the shared endpoint/auth/TLS value used by Cli, Server, Cluster, Sentinel, and Manager
- make readiness, commands, health, shutdown, cluster formation, Sentinel queries, and persisted Manager teardown retain the same connection
- support plaintext TCP, TLS, and Unix-socket redis-cli transports
- support named ACL users separately from password-only `requirepass`, including replication `masteruser` and Sentinel `auth-user`
- support CA files/directories, client certificates/keys, SNI, and explicit insecure client verification
- enable `tls-cluster` and `tls-replication` automatically for TLS topologies
- make Sentinel listeners and monitoring operational over TLS
- preserve transport/auth data in Manager state and use Unix-socket ownership checks for safe teardown
- return early errors for missing endpoints/certificates, unsupported topology sockets, default TLS client-auth mismatches, and non-portable Unix socket paths
- make `Cli.shutdown/1` synchronous so delayed cleanup cannot shut down a replacement process on a reused endpoint
- document TCP, TLS, Unix, ACL, mTLS, Cluster, and Sentinel usage

## Integration coverage

- Unix-only standalone server with TCP disabled
- named ACL standalone server
- mutual-TLS standalone server with CA verification and SNI
- TLS-only 3-master Cluster
- TLS-only Sentinel with named ACL monitoring and replication
- Manager-persisted Unix-socket lifecycle

## Validation

- `mix test` — 88 passed
- `mix test --cover` — 88 passed, 90.27% total
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`
- `mix hex.build`