### PR TITLE
Make topology lifecycle reflect child exits and convergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,28 @@ instead of being overwritten.
 - `managed: false` - `redis-server` daemonizes independently; the caller owns the
   OS process lifecycle.
 
+If a managed Redis process exits unexpectedly, its `Server` GenServer now exits
+with an abnormal `{:redis_server_exit, backend, reason}` reason. A normal OTP
+supervisor therefore restarts the complete Server child instead of retaining a
+live GenServer with a missing OS process. Port and Forcola backends follow the
+same contract.
+
+Cluster and Sentinel make topology loss explicit:
+
+- Cluster removes a dead node from `Cluster.nodes/1`, stays available for chaos
+  and failover work, and reports both `all_alive?/1` and `healthy?/1` as false.
+  `healthy?/1` validates every remaining node's state, slot coverage, failure
+  counts, known-node count, and master count.
+- Sentinel uses the selected managed backend for its control processes as well
+  as its data nodes. Loss of a master, replica, or Sentinel control process
+  stops the topology abnormally after cleaning up the remaining children, so a
+  supervisor can restart the complete topology from a coherent state.
+
+Cluster formation, replica linkage, and Sentinel discovery use bounded polling
+instead of fixed startup sleeps. Set `convergence_timeout: milliseconds` to
+override the default (the value of `:timeout`). Timeout errors include the last
+observed health state to make transitional or malformed Redis output diagnosable.
+
 ### Custom Modules
 
 Use `:loadmodule` to load one or more Redis modules. A plain path is enough for

--- a/lib/redis_server_wrapper/cluster.ex
+++ b/lib/redis_server_wrapper/cluster.ex
@@ -39,6 +39,8 @@ defmodule RedisServerWrapper.Cluster do
     * `:redis_cli_bin` - redis-cli binary path
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
     * `:timeout` - startup timeout per node in ms (default: 10_000)
+    * `:convergence_timeout` - bounded wait for every node to agree on the
+      cluster topology (default: the value of `:timeout`)
     * `:cluster_node_timeout` - cluster node timeout in ms (default: 5000)
     * `:loadmodule` - modules loaded into every cluster node; accepts paths or
       `{path, [args]}` tuples (default: `[]`)
@@ -65,6 +67,7 @@ defmodule RedisServerWrapper.Cluster do
     :password,
     :redis_cli_bin,
     node_pids: [],
+    node_ports: %{},
     detached: false
   ]
 
@@ -96,11 +99,14 @@ defmodule RedisServerWrapper.Cluster do
   @spec nodes(GenServer.server()) :: [pid()]
   def nodes(server), do: GenServer.call(server, :nodes)
 
-  @doc "Checks if all nodes respond to PING."
+  @doc "Checks if every tracked node process is alive and responds to PING."
   @spec all_alive?(GenServer.server()) :: boolean()
   def all_alive?(server), do: GenServer.call(server, :all_alive?)
 
-  @doc "Checks cluster health via CLUSTER INFO (state=ok, all slots assigned)."
+  @doc """
+  Checks every node's `CLUSTER INFO`, including state, slots, failures,
+  expected node count, and expected master count.
+  """
   @spec healthy?(GenServer.server()) :: boolean()
   def healthy?(server), do: GenServer.call(server, :healthy?)
 
@@ -142,6 +148,7 @@ defmodule RedisServerWrapper.Cluster do
     distribution = Keyword.get(opts, :distribution, :core)
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, 10_000)
+    convergence_timeout = Keyword.get(opts, :convergence_timeout, timeout)
     cluster_node_timeout = Keyword.get(opts, :cluster_node_timeout, 5000)
     loadmodule = Keyword.get(opts, :loadmodule, [])
     extra = Keyword.get(opts, :extra, [])
@@ -178,6 +185,7 @@ defmodule RedisServerWrapper.Cluster do
            redis_server_bin: redis_server_bin,
            redis_cli_bin: redis_cli_bin,
            timeout: timeout,
+           convergence_timeout: convergence_timeout,
            cluster_node_timeout: cluster_node_timeout,
            loadmodule: loadmodule,
            extra: extra,
@@ -211,22 +219,23 @@ defmodule RedisServerWrapper.Cluster do
   end
 
   def handle_call(:all_alive?, _from, state) do
-    all = Enum.all?(state.node_pids, &Server.ping/1)
+    expected_nodes = state.masters * (1 + state.replicas_per_master)
+
+    all =
+      length(state.node_pids) == expected_nodes and
+        Enum.all?(state.node_pids, &safe_server_ping/1)
+
     {:reply, all, state}
   end
 
   def handle_call(:healthy?, _from, state) do
-    seed_cli = seed_cli(state)
+    expected_nodes = state.masters * (1 + state.replicas_per_master)
 
     result =
-      case Cli.cluster_info(seed_cli) do
-        {:ok, info} ->
-          info["cluster_state"] == "ok" &&
-            info["cluster_slots_assigned"] == "16384"
-
-        _ ->
-          false
-      end
+      match?(
+        {:ok, _snapshot},
+        cluster_health(state.node_pids, state.masters, expected_nodes)
+      )
 
     {:reply, result, state}
   end
@@ -263,11 +272,24 @@ defmodule RedisServerWrapper.Cluster do
 
   @impl true
   def handle_info({:EXIT, pid, reason}, state) do
-    if pid in state.node_pids and reason != :normal do
-      Logger.warning("Cluster node #{inspect(pid)} exited: #{inspect(reason)}")
-    end
+    case Enum.find_index(state.node_pids, &(&1 == pid)) do
+      nil ->
+        {:noreply, state}
 
-    {:noreply, state}
+      index ->
+        port = Map.get(state.node_ports, pid, state.base_port + index)
+
+        Logger.warning(
+          "Cluster node on port #{port} exited; topology is degraded: #{inspect(reason)}"
+        )
+
+        {:noreply,
+         %{
+           state
+           | node_pids: List.delete(state.node_pids, pid),
+             node_ports: Map.delete(state.node_ports, pid)
+         }}
+    end
   end
 
   @impl true
@@ -316,6 +338,7 @@ defmodule RedisServerWrapper.Cluster do
         :redis_server_bin,
         :redis_cli_bin,
         :timeout,
+        :convergence_timeout,
         :cluster_node_timeout,
         :loadmodule,
         :extra,
@@ -337,27 +360,36 @@ defmodule RedisServerWrapper.Cluster do
 
     case Cli.cluster_create(seed_cli, node_addr_list, settings.replicas_per_master) do
       {:ok, _output} ->
-        # Wait for cluster convergence
-        Process.sleep(2000)
+        case await_cluster_convergence(
+               node_pids,
+               settings.masters,
+               settings.convergence_timeout
+             ) do
+          {:ok, _snapshot} ->
+            {:ok,
+             %__MODULE__{
+               masters: settings.masters,
+               replicas_per_master: settings.replicas_per_master,
+               base_port: settings.base_port,
+               bind: settings.bind,
+               control_host: settings.control_host,
+               connection: settings.connection,
+               username: settings.username,
+               password: settings.password,
+               redis_cli_bin: settings.redis_cli_bin,
+               node_pids: node_pids,
+               node_ports: Map.new(Enum.zip(node_pids, ports))
+             }}
 
-        state = %__MODULE__{
-          masters: settings.masters,
-          replicas_per_master: settings.replicas_per_master,
-          base_port: settings.base_port,
-          bind: settings.bind,
-          control_host: settings.control_host,
-          connection: settings.connection,
-          username: settings.username,
-          password: settings.password,
-          redis_cli_bin: settings.redis_cli_bin,
-          node_pids: node_pids
-        }
+          {:error, last_health} ->
+            stop_servers(node_pids)
 
-        {:ok, state}
+            {:stop, {:cluster_convergence_timeout, settings.convergence_timeout, last_health}}
+        end
 
       {:error, reason} ->
         # Rollback: stop all nodes
-        Enum.each(node_pids, &Server.stop/1)
+        stop_servers(node_pids)
         {:stop, {:cluster_create_failed, reason}}
     end
   end
@@ -389,12 +421,16 @@ defmodule RedisServerWrapper.Cluster do
 
           {:error, reason} ->
             # Rollback already-started nodes
-            Enum.each(acc, &Server.stop/1)
+            stop_servers(acc)
             {:halt, {:error, {:node_start_failed, port, reason}}}
         end
       end)
 
     results
+  end
+
+  defp seed_cli(%{node_pids: [server | _rest]}) do
+    Server.cli(server)
   end
 
   defp seed_cli(state) do
@@ -504,12 +540,113 @@ defmodule RedisServerWrapper.Cluster do
     end)
   end
 
+  defp await_cluster_convergence(node_pids, masters, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_cluster_convergence(node_pids, masters, deadline, nil)
+  end
+
+  defp do_await_cluster_convergence(node_pids, masters, deadline, _last_health) do
+    case cluster_health(node_pids, masters, length(node_pids)) do
+      {:ok, _snapshot} = healthy ->
+        healthy
+
+      {:error, _reason} = unhealthy ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          unhealthy
+        else
+          Process.sleep(100)
+          do_await_cluster_convergence(node_pids, masters, deadline, unhealthy)
+        end
+    end
+  end
+
+  defp cluster_health(node_pids, masters, expected_nodes)
+       when length(node_pids) == expected_nodes do
+    node_pids
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {pid, index}, {:ok, snapshots} ->
+      with {:ok, cli} <- safe_server_cli(pid),
+           true <- Cli.ping(cli),
+           {:ok, info} <- Cli.cluster_info(cli),
+           :ok <- valid_cluster_info(info, expected_nodes, masters) do
+        {:cont, {:ok, [info | snapshots]}}
+      else
+        false ->
+          {:halt, {:error, {:node_unreachable, index}}}
+
+        {:error, reason} ->
+          {:halt, {:error, {:node_health_failed, index, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, snapshots} -> {:ok, Enum.reverse(snapshots)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp cluster_health(node_pids, _masters, expected_nodes),
+    do: {:error, {:unexpected_node_count, expected_nodes, length(node_pids)}}
+
+  defp valid_cluster_info(info, expected_nodes, masters) do
+    expected = %{
+      "cluster_state" => "ok",
+      "cluster_slots_assigned" => 16_384,
+      "cluster_slots_ok" => 16_384,
+      "cluster_slots_pfail" => 0,
+      "cluster_slots_fail" => 0,
+      "cluster_known_nodes" => expected_nodes,
+      "cluster_size" => masters
+    }
+
+    invalid =
+      Enum.reduce(expected, %{}, fn
+        {"cluster_state" = key, value}, acc ->
+          if Map.get(info, key) == value,
+            do: acc,
+            else: Map.put(acc, key, Map.get(info, key))
+
+        {key, value}, acc ->
+          case parse_integer(Map.get(info, key)) do
+            {:ok, ^value} -> acc
+            _other -> Map.put(acc, key, Map.get(info, key))
+          end
+      end)
+
+    if map_size(invalid) == 0 do
+      :ok
+    else
+      {:error, {:invalid_cluster_info, invalid}}
+    end
+  end
+
+  defp safe_server_cli(server) do
+    {:ok, Server.cli(server)}
+  catch
+    :exit, reason -> {:error, {:server_exit, reason}}
+  end
+
+  defp safe_server_ping(server) do
+    Server.ping(server)
+  catch
+    :exit, _reason -> false
+  end
+
+  defp parse_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> {:ok, integer}
+      _other -> :error
+    end
+  end
+
+  defp parse_integer(_value), do: :error
+
   defp validate_options(settings) do
     with :ok <- positive_integer(:masters, settings.masters),
          :ok <-
            non_negative_integer(:replicas_per_master, settings.replicas_per_master),
          :ok <- valid_port(:base_port, settings.base_port),
          :ok <- positive_integer(:timeout, settings.timeout),
+         :ok <- positive_integer(:convergence_timeout, settings.convergence_timeout),
          :ok <- positive_integer(:cluster_node_timeout, settings.cluster_node_timeout) do
       total_nodes = settings.masters * (1 + settings.replicas_per_master)
       last_data_port = settings.base_port + total_nodes - 1

--- a/lib/redis_server_wrapper/managed_process.ex
+++ b/lib/redis_server_wrapper/managed_process.ex
@@ -1,0 +1,254 @@
+defmodule RedisServerWrapper.ManagedProcess do
+  @moduledoc false
+
+  use GenServer
+
+  alias RedisServerWrapper.OSProcess
+
+  require Logger
+
+  @compile {:no_warn_undefined, Forcola.Daemon}
+
+  defstruct [
+    :backend,
+    :daemon,
+    :label,
+    :os_pid,
+    :port_ref,
+    :shutdown
+  ]
+
+  @type backend :: true | :forcola
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  @spec info(GenServer.server()) :: %{backend: backend(), pid: pos_integer() | nil}
+  def info(server), do: GenServer.call(server, :info)
+
+  @spec stop(GenServer.server()) :: :ok
+  def stop(server), do: GenServer.stop(server, :normal)
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    backend = Keyword.fetch!(opts, :backend)
+    argv = Keyword.fetch!(opts, :argv)
+    ready = Keyword.fetch!(opts, :ready)
+    timeout = Keyword.fetch!(opts, :ready_timeout_ms)
+    label = Keyword.get(opts, :label, "managed process")
+    pid_path = Keyword.get(opts, :pid_path)
+    shutdown = Keyword.get(opts, :shutdown, fn -> :ok end)
+
+    with :ok <- validate_backend(backend),
+         {:ok, executable, args} <- resolve_argv(argv) do
+      start_backend(backend, executable, args, ready, timeout, label, pid_path, shutdown)
+    else
+      {:error, reason} -> {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call(:info, _from, state) do
+    {:reply, %{backend: state.backend, pid: state.os_pid}, state}
+  end
+
+  @impl true
+  def handle_info({:EXIT, daemon, reason}, %{daemon: daemon} = state)
+      when is_pid(daemon) do
+    stop_reason = {:managed_process_exit, state.label, :forcola, reason}
+    Logger.warning("#{state.label} exited under Forcola: #{inspect(reason)}")
+    {:stop, stop_reason, %{state | daemon: nil, os_pid: nil}}
+  end
+
+  def handle_info({port_ref, {:exit_status, status}}, %{port_ref: port_ref} = state)
+      when is_port(port_ref) do
+    stop_reason = {:managed_process_exit, state.label, :port, {:exit_status, status}}
+    Logger.warning("#{state.label} exited with status #{status}")
+    {:stop, stop_reason, %{state | port_ref: nil, os_pid: nil}}
+  end
+
+  def handle_info({:EXIT, port_ref, reason}, %{port_ref: port_ref} = state)
+      when is_port(port_ref) do
+    stop_reason = {:managed_process_exit, state.label, :port, reason}
+    Logger.warning("#{state.label} port exited: #{inspect(reason)}")
+    {:stop, stop_reason, %{state | port_ref: nil, os_pid: nil}}
+  end
+
+  def handle_info({port_ref, {:data, {:eol, line}}}, %{port_ref: port_ref} = state)
+      when is_port(port_ref) do
+    Logger.debug("#{state.label}: #{line}")
+    {:noreply, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, %{daemon: daemon}) when is_pid(daemon) do
+    if Process.alive?(daemon) do
+      GenServer.stop(daemon, :normal, :infinity)
+    end
+
+    :ok
+  catch
+    :exit, _reason -> :ok
+  end
+
+  def terminate(_reason, state) do
+    safe_shutdown(state.shutdown)
+    await_process_exit(state.os_pid, 500)
+    safe_port_close(state.port_ref)
+
+    if OSProcess.alive?(state.os_pid) do
+      _result = OSProcess.signal(state.os_pid, :kill)
+    end
+
+    :ok
+  end
+
+  defp start_backend(true, executable, args, ready, timeout, label, _pid_path, shutdown) do
+    port_ref =
+      Port.open({:spawn_executable, executable}, [
+        {:args, args},
+        :binary,
+        :exit_status,
+        {:line, 1024}
+      ])
+
+    case await_ready(ready, timeout, fn -> Port.info(port_ref) != nil end) do
+      :ok ->
+        {:os_pid, os_pid} = Port.info(port_ref, :os_pid)
+
+        {:ok,
+         %__MODULE__{
+           backend: true,
+           label: label,
+           os_pid: os_pid,
+           port_ref: port_ref,
+           shutdown: shutdown
+         }}
+
+      {:error, reason} ->
+        safe_port_close(port_ref)
+        {:stop, {:managed_process_start_failed, label, reason}}
+    end
+  rescue
+    error in ArgumentError ->
+      {:stop, {:managed_process_start_failed, label, Exception.message(error)}}
+  end
+
+  defp start_backend(:forcola, executable, args, ready, timeout, label, pid_path, shutdown) do
+    if Code.ensure_loaded?(Forcola.Daemon) do
+      daemon_opts = [
+        argv: [executable | args],
+        ready: ready,
+        ready_timeout_ms: timeout,
+        output: :logger,
+        log_output: :debug,
+        log_prefix: "#{label}: "
+      ]
+
+      case Forcola.Daemon.start_link(daemon_opts) do
+        {:ok, daemon} ->
+          {:ok,
+           %__MODULE__{
+             backend: :forcola,
+             daemon: daemon,
+             label: label,
+             os_pid: read_pidfile(pid_path),
+             shutdown: shutdown
+           }}
+
+        {:error, reason} ->
+          {:stop, {:managed_process_start_failed, label, reason}}
+      end
+    else
+      {:stop, :forcola_not_available}
+    end
+  end
+
+  defp validate_backend(backend) when backend in [true, :forcola], do: :ok
+  defp validate_backend(backend), do: {:error, {:invalid_managed, backend}}
+
+  defp resolve_argv([executable | args]) when is_binary(executable) and is_list(args) do
+    case System.find_executable(executable) do
+      nil -> {:error, {:executable_not_found, executable}}
+      path -> {:ok, path, Enum.map(args, &to_string/1)}
+    end
+  end
+
+  defp resolve_argv(argv), do: {:error, {:invalid_argv, argv}}
+
+  defp await_ready(ready, timeout, alive?) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_ready(ready, deadline, alive?)
+  end
+
+  defp do_await_ready(ready, deadline, alive?) do
+    cond do
+      not alive?.() ->
+        {:error, :exited_before_ready}
+
+      ready.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        {:error, :ready_timeout}
+
+      true ->
+        Process.sleep(50)
+        do_await_ready(ready, deadline, alive?)
+    end
+  end
+
+  defp safe_shutdown(shutdown) do
+    shutdown.()
+    :ok
+  rescue
+    _error -> :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp await_process_exit(nil, _timeout), do: :ok
+
+  defp await_process_exit(pid, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_process_exit(pid, deadline)
+  end
+
+  defp do_await_process_exit(pid, deadline) do
+    cond do
+      not OSProcess.alive?(pid) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        :timeout
+
+      true ->
+        Process.sleep(25)
+        do_await_process_exit(pid, deadline)
+    end
+  end
+
+  defp safe_port_close(port_ref) when is_port(port_ref) do
+    if Port.info(port_ref) != nil, do: Port.close(port_ref)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp safe_port_close(_port_ref), do: :ok
+
+  defp read_pidfile(nil), do: nil
+
+  defp read_pidfile(path) do
+    with {:ok, content} <- File.read(path),
+         {pid, ""} <- content |> String.trim() |> Integer.parse(),
+         true <- pid > 0 do
+      pid
+    else
+      _other -> nil
+    end
+  end
+end

--- a/lib/redis_server_wrapper/sentinel.ex
+++ b/lib/redis_server_wrapper/sentinel.ex
@@ -40,24 +40,35 @@ defmodule RedisServerWrapper.Sentinel do
     * `:redis_cli_bin` - redis-cli binary path
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
     * `:timeout` - startup timeout per node in ms (default: 10_000)
+    * `:convergence_timeout` - bounded wait for replication and Sentinel
+      discovery (default: the value of `:timeout`)
     * `:loadmodule` - modules loaded into the master and every replica; accepts
       paths or `{path, [args]}` tuples (default: `[]`). Sentinel processes do
       not load data modules.
     * `:managed` - process lifecycle backend forwarded to the master and every
       replica. See `RedisServerWrapper.Server` for `true`, `:forcola`, and
-      `false`. Only `managed: false` supports `detach/1`. Sentinel processes
-      always daemonize regardless of this flag.
+      `false`. Sentinel control processes use the same selected backend. Only
+      `managed: false` supports `detach/1`.
   """
 
   use GenServer
 
-  alias RedisServerWrapper.{Cli, Config, Connection, OSProcess, SecureFile, Server}
+  alias RedisServerWrapper.{
+    Cli,
+    Config,
+    Connection,
+    ManagedProcess,
+    OSProcess,
+    SecureFile,
+    Server
+  }
 
   require Logger
 
   defstruct [
     :master_name,
     :master_port,
+    :replica_base_port,
     :bind,
     :control_host,
     :master_connection,
@@ -65,11 +76,13 @@ defmodule RedisServerWrapper.Sentinel do
     :username,
     :password,
     :redis_cli_bin,
+    :managed,
     :master_pid,
     :num_replicas,
     :num_sentinels,
     replica_pids: [],
     sentinel_os_pids: [],
+    sentinel_processes: [],
     sentinel_ports: [],
     sentinel_dir: nil,
     detached: false
@@ -154,6 +167,7 @@ defmodule RedisServerWrapper.Sentinel do
     distribution = Keyword.get(opts, :distribution, :core)
     redis_cli_bin = Keyword.get(opts, :redis_cli_bin, "redis-cli")
     timeout = Keyword.get(opts, :timeout, 10_000)
+    convergence_timeout = Keyword.get(opts, :convergence_timeout, timeout)
     loadmodule = Keyword.get(opts, :loadmodule, [])
     managed = Keyword.get(opts, :managed, true)
 
@@ -165,9 +179,19 @@ defmodule RedisServerWrapper.Sentinel do
            Keyword.get_lazy(opts, :redis_server_bin, fn ->
              Server.default_server_bin(distribution)
            end),
-         node_opts = %{
+         settings = %{
+           master_name: master_name,
+           master_port: master_port,
+           replicas: num_replicas,
+           replica_base_port: replica_base_port,
+           sentinels: num_sentinels,
+           sentinel_base_port: sentinel_base_port,
+           quorum: quorum,
+           down_after_ms: down_after_ms,
+           failover_timeout_ms: failover_timeout_ms,
            bind: bind,
            control_host: control_host,
+           master_connection: master_connection,
            username: username,
            password: password,
            tls: master_connection.transport == :tls,
@@ -184,80 +208,14 @@ defmodule RedisServerWrapper.Sentinel do
            redis_server_bin: redis_server_bin,
            redis_cli_bin: redis_cli_bin,
            timeout: timeout,
+           convergence_timeout: convergence_timeout,
            loadmodule: loadmodule,
            managed: managed
          },
-         validation_settings = %{
-           master_port: master_port,
-           replicas: num_replicas,
-           replica_base_port: replica_base_port,
-           sentinels: num_sentinels,
-           sentinel_base_port: sentinel_base_port,
-           quorum: quorum,
-           down_after_ms: down_after_ms,
-           failover_timeout_ms: failover_timeout_ms,
-           timeout: timeout
-         },
-         :ok <- validate_server_connection_config(node_opts, master_port),
-         :ok <- validate_options(validation_settings),
-         {:ok, master_pid} <- start_master(master_port, node_opts),
-         {:ok, replica_pids} <-
-           start_replicas(num_replicas, replica_base_port, master_port, node_opts),
-         # Let replication link up
-         _ <- Process.sleep(1000),
-         {:ok, sentinel_os_pids, sentinel_dir} <-
-           start_sentinels(%{
-             count: num_sentinels,
-             base_port: sentinel_base_port,
-             master_name: master_name,
-             master_port: master_port,
-             bind: bind,
-             control_host: control_host,
-             username: username,
-             password: password,
-             tls: master_connection.transport == :tls,
-             tls_cert_file: Keyword.get(opts, :tls_cert_file),
-             tls_key_file: Keyword.get(opts, :tls_key_file),
-             tls_ca_cert_file: Keyword.get(opts, :tls_ca_cert_file),
-             tls_ca_cert_dir: Keyword.get(opts, :tls_ca_cert_dir),
-             tls_auth_clients: Keyword.get(opts, :tls_auth_clients),
-             tls_client_cert_file: Keyword.get(opts, :tls_client_cert_file),
-             tls_client_key_file: Keyword.get(opts, :tls_client_key_file),
-             tls_server_name: Keyword.get(opts, :tls_server_name),
-             tls_insecure: Keyword.get(opts, :tls_insecure, false),
-             quorum: quorum,
-             down_after_ms: down_after_ms,
-             failover_timeout_ms: failover_timeout_ms,
-             redis_server_bin: redis_server_bin,
-             redis_cli_bin: redis_cli_bin,
-             timeout: timeout
-           }) do
-      # Wait for sentinel discovery
-      Process.sleep(2000)
-
-      sentinel_ports = ports_from(sentinel_base_port, num_sentinels)
-      sentinel_connection = Connection.with_port(master_connection, sentinel_base_port)
-
-      state = %__MODULE__{
-        master_name: master_name,
-        master_port: master_port,
-        bind: bind,
-        control_host: control_host,
-        master_connection: master_connection,
-        sentinel_connection: sentinel_connection,
-        username: username,
-        password: password,
-        redis_cli_bin: redis_cli_bin,
-        master_pid: master_pid,
-        num_replicas: num_replicas,
-        num_sentinels: num_sentinels,
-        replica_pids: replica_pids,
-        sentinel_os_pids: sentinel_os_pids,
-        sentinel_ports: sentinel_ports,
-        sentinel_dir: sentinel_dir
-      }
-
-      {:ok, state}
+         :ok <- validate_server_connection_config(settings, master_port),
+         :ok <- validate_options(settings),
+         :ok <- check_sentinel_endpoints(settings) do
+      start_validated_sentinel(settings)
     else
       {:error, reason} ->
         {:stop, reason}
@@ -284,6 +242,7 @@ defmodule RedisServerWrapper.Sentinel do
       master_addr: format_addr(state.control_host, state.master_port),
       replicas: state.num_replicas,
       sentinels: state.num_sentinels,
+      managed: state.managed,
       sentinel_addrs: Enum.map(state.sentinel_ports, &format_addr(state.control_host, &1))
     }
 
@@ -291,28 +250,7 @@ defmodule RedisServerWrapper.Sentinel do
   end
 
   def handle_call(:healthy?, _from, state) do
-    result =
-      Enum.any?(state.sentinel_ports, fn port ->
-        cli =
-          Cli.new(
-            bin: state.redis_cli_bin,
-            connection: Connection.with_port(state.sentinel_connection, port)
-          )
-
-        case Cli.sentinel_master(cli, state.master_name) do
-          {:ok, info} ->
-            flags = Map.get(info, "flags", "")
-            num_slaves = String.to_integer(Map.get(info, "num-slaves", "0"))
-            num_sentinels = String.to_integer(Map.get(info, "num-other-sentinels", "0")) + 1
-
-            flags == "master" &&
-              num_slaves >= state.num_replicas &&
-              num_sentinels >= state.num_sentinels
-
-          _ ->
-            false
-        end
-      end)
+    result = match?({:ok, _snapshot}, sentinel_health(state))
 
     {:reply, result, state}
   end
@@ -344,37 +282,48 @@ defmodule RedisServerWrapper.Sentinel do
 
   @impl true
   def handle_info({:EXIT, pid, reason}, state) do
-    if reason != :normal do
-      Logger.warning("Sentinel topology process #{inspect(pid)} exited: #{inspect(reason)}")
-    end
+    cond do
+      pid == state.master_pid ->
+        stop_reason = {:sentinel_data_node_exit, :master, state.master_port, reason}
+        Logger.warning("Sentinel master exited: #{inspect(reason)}")
+        {:stop, stop_reason, %{state | master_pid: nil}}
 
-    {:noreply, state}
+      pid in state.replica_pids ->
+        index = Enum.find_index(state.replica_pids, &(&1 == pid))
+        port = replica_port(state, index)
+        stop_reason = {:sentinel_data_node_exit, :replica, port, reason}
+        Logger.warning("Sentinel replica on port #{port} exited: #{inspect(reason)}")
+        {:stop, stop_reason, %{state | replica_pids: List.delete(state.replica_pids, pid)}}
+
+      process = Enum.find(state.sentinel_processes, &(&1.owner == pid)) ->
+        stop_reason = {:sentinel_control_exit, process.port, reason}
+
+        Logger.warning(
+          "Sentinel control process on port #{process.port} exited: #{inspect(reason)}"
+        )
+
+        {:stop, stop_reason,
+         %{state | sentinel_processes: List.delete(state.sentinel_processes, process)}}
+
+      true ->
+        {:noreply, state}
+    end
   end
 
   @impl true
   def terminate(_reason, %{detached: true} = state) do
     Logger.debug("RedisServerWrapper.Sentinel terminating (OS processes detached)")
-    stop_servers(state.replica_pids ++ [state.master_pid])
+    stop_servers(state.replica_pids ++ List.wrap(state.master_pid))
     :ok
   end
 
   def terminate(_reason, state) do
     Logger.debug("RedisServerWrapper.Sentinel terminating, stopping topology")
 
-    # Stop sentinels first (they're raw OS processes, not GenServers)
-    Enum.each(state.sentinel_os_pids, fn pid ->
-      OSProcess.signal(pid, :term)
-    end)
-
-    Process.sleep(500)
-
-    # Force kill any remaining sentinel processes
-    Enum.each(state.sentinel_os_pids, fn pid ->
-      if OSProcess.alive?(pid), do: OSProcess.signal(pid, :kill)
-    end)
+    stop_sentinel_processes(state.sentinel_processes)
 
     # Stop replicas, then master
-    stop_servers(state.replica_pids ++ [state.master_pid])
+    stop_servers(state.replica_pids ++ List.wrap(state.master_pid))
 
     # Clean up sentinel config directory
     if state.sentinel_dir, do: File.rm_rf(state.sentinel_dir)
@@ -385,6 +334,102 @@ defmodule RedisServerWrapper.Sentinel do
   # -------------------------------------------------------------------
   # Internal
   # -------------------------------------------------------------------
+
+  defp start_validated_sentinel(settings) do
+    case start_master(settings.master_port, settings) do
+      {:ok, master_pid} ->
+        start_validated_replicas(master_pid, settings)
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  defp start_validated_replicas(master_pid, settings) do
+    case start_replicas(
+           settings.replicas,
+           settings.replica_base_port,
+           settings.master_port,
+           settings
+         ) do
+      {:ok, replica_pids} ->
+        await_replication_and_start_sentinels(master_pid, replica_pids, settings)
+
+      {:error, reason} ->
+        stop_servers([master_pid])
+        {:stop, reason}
+    end
+  end
+
+  defp await_replication_and_start_sentinels(master_pid, replica_pids, settings) do
+    case await_replication(
+           replica_pids,
+           settings.control_host,
+           settings.master_port,
+           settings.convergence_timeout
+         ) do
+      {:ok, _snapshot} ->
+        start_validated_sentinel_processes(master_pid, replica_pids, settings)
+
+      {:error, last_health} ->
+        stop_servers(replica_pids ++ [master_pid])
+
+        {:stop, {:replication_convergence_timeout, settings.convergence_timeout, last_health}}
+    end
+  end
+
+  defp start_validated_sentinel_processes(master_pid, replica_pids, settings) do
+    case start_sentinels(settings) do
+      {:ok, sentinel_processes, sentinel_dir} ->
+        state =
+          sentinel_state(master_pid, replica_pids, sentinel_processes, sentinel_dir, settings)
+
+        case await_sentinel_convergence(state, settings.convergence_timeout) do
+          {:ok, _snapshot} ->
+            {:ok, state}
+
+          {:error, last_health} ->
+            stop_sentinel_processes(sentinel_processes)
+            stop_servers(replica_pids ++ [master_pid])
+            File.rm_rf(sentinel_dir)
+
+            {:stop, {:sentinel_convergence_timeout, settings.convergence_timeout, last_health}}
+        end
+
+      {:error, reason} ->
+        stop_servers(replica_pids ++ [master_pid])
+        {:stop, reason}
+    end
+  end
+
+  defp sentinel_state(master_pid, replica_pids, sentinel_processes, sentinel_dir, settings) do
+    sentinel_ports = ports_from(settings.sentinel_base_port, settings.sentinels)
+
+    sentinel_connection =
+      Connection.with_port(settings.master_connection, settings.sentinel_base_port)
+
+    %__MODULE__{
+      master_name: settings.master_name,
+      master_port: settings.master_port,
+      replica_base_port: settings.replica_base_port,
+      bind: settings.bind,
+      control_host: settings.control_host,
+      master_connection: settings.master_connection,
+      sentinel_connection: sentinel_connection,
+      username: settings.username,
+      password: settings.password,
+      redis_cli_bin: settings.redis_cli_bin,
+      managed: settings.managed,
+      master_pid: master_pid,
+      num_replicas: settings.replicas,
+      num_sentinels: settings.sentinels,
+      replica_pids: replica_pids,
+      sentinel_os_pids: Enum.flat_map(sentinel_processes, &List.wrap(&1.os_pid)),
+      sentinel_processes: sentinel_processes,
+      sentinel_ports: sentinel_ports,
+      sentinel_dir: sentinel_dir
+    }
+  end
 
   defp start_master(port, node_opts) do
     Server.start_link(
@@ -432,7 +477,7 @@ defmodule RedisServerWrapper.Sentinel do
             {:cont, {:ok, acc ++ [pid]}}
 
           {:error, reason} ->
-            Enum.each(acc, &Server.stop/1)
+            stop_servers(acc)
             {:halt, {:error, {:replica_start_failed, port, reason}}}
         end
       end)
@@ -441,7 +486,8 @@ defmodule RedisServerWrapper.Sentinel do
   end
 
   defp start_sentinels(opts) do
-    %{count: count, base_port: base_port} = opts
+    count = opts.sentinels
+    base_port = opts.sentinel_base_port
 
     sentinel_dir =
       Path.join([
@@ -457,17 +503,18 @@ defmodule RedisServerWrapper.Sentinel do
         port = base_port + i
 
         case start_single_sentinel(opts, sentinel_dir, port) do
-          {:ok, os_pid} ->
-            {:cont, {:ok, acc ++ [os_pid]}}
+          {:ok, process} ->
+            {:cont, {:ok, acc ++ [process]}}
 
           {:error, reason} ->
-            kill_pids(acc)
+            stop_sentinel_processes(acc)
+            File.rm_rf(sentinel_dir)
             {:halt, {:error, {:sentinel_start_failed, port, reason}}}
         end
       end)
 
     case results do
-      {:ok, pids} -> {:ok, pids, sentinel_dir}
+      {:ok, processes} -> {:ok, processes, sentinel_dir}
       error -> error
     end
   end
@@ -486,7 +533,8 @@ defmodule RedisServerWrapper.Sentinel do
       node_dir,
       opts.redis_cli_bin,
       sentinel_connection(opts, port),
-      opts.timeout
+      opts.timeout,
+      opts.managed
     )
   end
 
@@ -510,7 +558,7 @@ defmodule RedisServerWrapper.Sentinel do
       [
         Config.directive("port", [if(tls, do: 0, else: port)]),
         Config.directive("bind", listen_addresses),
-        Config.directive("daemonize", ["yes"]),
+        Config.directive("daemonize", [if(opts.managed == false, do: "yes", else: "no")]),
         Config.directive("pidfile", [Path.join(dir, "sentinel.pid")]),
         Config.directive("logfile", [Path.join(dir, "sentinel.log")]),
         Config.directive("dir", [dir]),
@@ -558,19 +606,14 @@ defmodule RedisServerWrapper.Sentinel do
   defp optional_directive(_key, nil), do: []
   defp optional_directive(key, value), do: [Config.directive(key, [value])]
 
-  defp kill_pids(pids) do
-    Enum.each(pids, fn pid ->
-      OSProcess.signal(pid, :term)
-    end)
-  end
-
   defp start_sentinel_process(
          redis_server_bin,
          conf_path,
          node_dir,
          redis_cli_bin,
          connection,
-         timeout
+         timeout,
+         false
        ) do
     # Sentinel rewrites its configuration as topology state changes. Launch it
     # with a private umask so every replacement keeps credential-bearing config
@@ -586,24 +629,69 @@ defmodule RedisServerWrapper.Sentinel do
 
     case System.cmd("/bin/sh", command_args, stderr_to_stdout: true) do
       {_output, 0} ->
-        # Wait for sentinel to be ready
         cli = Cli.new(bin: redis_cli_bin, connection: connection)
 
         case Cli.wait_for_ready(cli, timeout) do
           :ok ->
             pid_path = Path.join(node_dir, "sentinel.pid")
             pid = read_pidfile(pid_path)
-            {:ok, pid}
+            {:ok, %{managed: false, owner: nil, os_pid: pid, port: connection.port}}
 
           {:error, :timeout} ->
+            kill_pid(read_pidfile(Path.join(node_dir, "sentinel.pid")))
             {:error, {:sentinel_start_timeout, connection.port}}
 
           {:error, {:unexpected_reply, reply}} ->
+            kill_pid(read_pidfile(Path.join(node_dir, "sentinel.pid")))
             {:error, {:sentinel_port_in_use, connection.port, reply}}
         end
 
       {output, code} ->
         {:error, {:sentinel_start_failed, connection.port, code, output}}
+    end
+  end
+
+  defp start_sentinel_process(
+         redis_server_bin,
+         conf_path,
+         node_dir,
+         redis_cli_bin,
+         connection,
+         timeout,
+         managed
+       )
+       when managed in [true, :forcola] do
+    command_args = [
+      "-c",
+      ~S(umask 077; exec "$@"),
+      "redis-server-wrapper",
+      redis_server_bin,
+      conf_path,
+      "--sentinel"
+    ]
+
+    cli = Cli.new(bin: redis_cli_bin, connection: connection)
+    pid_path = Path.join(node_dir, "sentinel.pid")
+
+    case ManagedProcess.start_link(
+           backend: managed,
+           argv: ["/bin/sh" | command_args],
+           ready: fn -> Cli.ping(cli) end,
+           ready_timeout_ms: timeout,
+           pid_path: pid_path,
+           label: "redis-sentinel on #{Connection.label(connection)}",
+           shutdown: fn -> Cli.shutdown(cli) end
+         ) do
+      {:ok, owner} ->
+        %{pid: os_pid} = ManagedProcess.info(owner)
+
+        {:ok, %{managed: managed, owner: owner, os_pid: os_pid, port: connection.port}}
+
+      {:error, {:managed_process_start_failed, _label, :ready_timeout}} ->
+        {:error, {:sentinel_start_timeout, connection.port}}
+
+      {:error, reason} ->
+        {:error, {:sentinel_start_failed, connection.port, reason}}
     end
   end
 
@@ -682,10 +770,267 @@ defmodule RedisServerWrapper.Sentinel do
       {:error, {:invalid_connection_config, Exception.message(error)}}
   end
 
+  defp await_replication(replica_pids, host, port, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_replication(replica_pids, host, port, deadline)
+  end
+
+  defp do_await_replication(replica_pids, host, port, deadline) do
+    case replication_health(replica_pids, host, port) do
+      {:ok, _snapshot} = healthy ->
+        healthy
+
+      {:error, _reason} = unhealthy ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          unhealthy
+        else
+          Process.sleep(100)
+          do_await_replication(replica_pids, host, port, deadline)
+        end
+    end
+  end
+
+  defp replication_health([], _host, _port), do: {:ok, []}
+
+  defp replication_health(replica_pids, host, port) do
+    replica_pids
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {replica, index}, {:ok, snapshots} ->
+      with {:ok, output} <- safe_server_run(replica, ["INFO", "replication"]),
+           info = parse_info(output),
+           :ok <- valid_replication_info(info, host, port) do
+        {:cont, {:ok, [info | snapshots]}}
+      else
+        {:error, reason} ->
+          {:halt, {:error, {:replica_health_failed, index, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, snapshots} -> {:ok, Enum.reverse(snapshots)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp valid_replication_info(info, host, port) do
+    invalid =
+      %{}
+      |> maybe_invalid(
+        "role",
+        Map.get(info, "role") in ["slave", "replica"],
+        Map.get(info, "role")
+      )
+      |> maybe_invalid(
+        "master_link_status",
+        Map.get(info, "master_link_status") == "up",
+        Map.get(info, "master_link_status")
+      )
+      |> maybe_invalid(
+        "master_host",
+        Map.get(info, "master_host") == host,
+        Map.get(info, "master_host")
+      )
+      |> maybe_invalid(
+        "master_port",
+        parse_integer(Map.get(info, "master_port")) == {:ok, port},
+        Map.get(info, "master_port")
+      )
+
+    if map_size(invalid) == 0,
+      do: :ok,
+      else: {:error, {:invalid_replication_info, invalid}}
+  end
+
+  defp await_sentinel_convergence(state, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_sentinel_convergence(state, deadline)
+  end
+
+  defp do_await_sentinel_convergence(state, deadline) do
+    case sentinel_health(state) do
+      {:ok, _snapshot} = healthy ->
+        healthy
+
+      {:error, _reason} = unhealthy ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          unhealthy
+        else
+          Process.sleep(100)
+          do_await_sentinel_convergence(state, deadline)
+        end
+    end
+  end
+
+  defp sentinel_health(state) do
+    data_nodes = List.wrap(state.master_pid) ++ state.replica_pids
+
+    with true <- Enum.all?(data_nodes, &safe_server_ping/1),
+         true <- Enum.all?(state.sentinel_processes, &sentinel_process_alive?/1),
+         {:ok, reports} <- sentinel_reports(state) do
+      {:ok, reports}
+    else
+      false -> {:error, :topology_process_unreachable}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp sentinel_reports(state) do
+    state.sentinel_ports
+    |> Enum.reduce_while({:ok, []}, fn port, {:ok, reports} ->
+      cli =
+        Cli.new(
+          bin: state.redis_cli_bin,
+          connection: Connection.with_port(state.sentinel_connection, port)
+        )
+
+      with {:ok, info} <- Cli.sentinel_master(cli, state.master_name),
+           :ok <- valid_sentinel_info(info, state.num_replicas, state.num_sentinels) do
+        {:cont, {:ok, [info | reports]}}
+      else
+        {:error, reason} ->
+          {:halt, {:error, {:sentinel_health_failed, port, reason}}}
+      end
+    end)
+    |> case do
+      {:ok, reports} -> {:ok, Enum.reverse(reports)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp valid_sentinel_info(info, replicas, sentinels) do
+    flags =
+      info
+      |> Map.get("flags", "")
+      |> String.split(",", trim: true)
+      |> MapSet.new()
+
+    invalid =
+      %{}
+      |> maybe_invalid(
+        "flags",
+        MapSet.member?(flags, "master") and
+          Enum.all?(["s_down", "o_down", "disconnected"], &(not MapSet.member?(flags, &1))),
+        Map.get(info, "flags")
+      )
+      |> maybe_invalid(
+        "num-slaves",
+        integer_at_least?(Map.get(info, "num-slaves"), replicas),
+        Map.get(info, "num-slaves")
+      )
+      |> maybe_invalid(
+        "num-other-sentinels",
+        integer_at_least?(Map.get(info, "num-other-sentinels"), sentinels - 1),
+        Map.get(info, "num-other-sentinels")
+      )
+
+    if map_size(invalid) == 0,
+      do: :ok,
+      else: {:error, {:invalid_sentinel_info, invalid}}
+  end
+
+  defp sentinel_process_alive?(%{managed: false, os_pid: pid}), do: OSProcess.alive?(pid)
+
+  defp sentinel_process_alive?(%{owner: owner, os_pid: pid}) do
+    Process.alive?(owner) and (is_nil(pid) or OSProcess.alive?(pid))
+  end
+
+  defp stop_sentinel_processes(processes) do
+    Enum.each(processes, fn
+      %{managed: false, os_pid: pid} ->
+        kill_pid(pid)
+
+      %{owner: owner} ->
+        if is_pid(owner) and Process.alive?(owner) do
+          try do
+            ManagedProcess.stop(owner)
+          catch
+            :exit, _reason -> :ok
+          end
+        end
+    end)
+  end
+
+  defp kill_pid(nil), do: :ok
+
+  defp kill_pid(pid) do
+    _result = OSProcess.signal(pid, :term)
+    await_process_exit(pid, 500)
+
+    if OSProcess.alive?(pid) do
+      _result = OSProcess.signal(pid, :kill)
+    end
+
+    :ok
+  end
+
+  defp await_process_exit(pid, timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_process_exit(pid, deadline)
+  end
+
+  defp do_await_process_exit(pid, deadline) do
+    cond do
+      not OSProcess.alive?(pid) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        :timeout
+
+      true ->
+        Process.sleep(25)
+        do_await_process_exit(pid, deadline)
+    end
+  end
+
+  defp safe_server_run(server, args) do
+    Server.run(server, args)
+  catch
+    :exit, reason -> {:error, {:server_exit, reason}}
+  end
+
+  defp safe_server_ping(server) do
+    Server.ping(server)
+  catch
+    :exit, _reason -> false
+  end
+
+  defp parse_info(output) do
+    output
+    |> String.split(~r/\r?\n/, trim: true)
+    |> Enum.reject(&String.starts_with?(&1, "#"))
+    |> Enum.reduce(%{}, fn line, acc ->
+      case String.split(line, ":", parts: 2) do
+        [key, value] -> Map.put(acc, String.trim(key), String.trim(value))
+        _other -> acc
+      end
+    end)
+  end
+
+  defp maybe_invalid(invalid, _key, true, _actual), do: invalid
+  defp maybe_invalid(invalid, key, false, actual), do: Map.put(invalid, key, actual)
+
+  defp integer_at_least?(value, minimum) do
+    case parse_integer(value) do
+      {:ok, integer} -> integer >= minimum
+      :error -> false
+    end
+  end
+
+  defp parse_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> {:ok, integer}
+      _other -> :error
+    end
+  end
+
+  defp parse_integer(_value), do: :error
+
   defp read_pidfile(path) do
-    case File.read(path) do
-      {:ok, content} -> content |> String.trim() |> String.to_integer()
-      {:error, _} -> nil
+    with {:ok, content} <- File.read(path),
+         {pid, ""} <- content |> String.trim() |> Integer.parse(),
+         true <- pid > 0 do
+      pid
+    else
+      _other -> nil
     end
   end
 
@@ -699,6 +1044,7 @@ defmodule RedisServerWrapper.Sentinel do
          :ok <- positive_integer(:down_after_ms, settings.down_after_ms),
          :ok <- positive_integer(:failover_timeout_ms, settings.failover_timeout_ms),
          :ok <- positive_integer(:timeout, settings.timeout),
+         :ok <- positive_integer(:convergence_timeout, settings.convergence_timeout),
          :ok <-
            valid_port_span(:replicas, settings.replica_base_port, settings.replicas),
          :ok <-
@@ -746,8 +1092,38 @@ defmodule RedisServerWrapper.Sentinel do
   defp valid_port_span(key, base_port, _count),
     do: {:error, {:invalid_option, :"#{key}_base_port", base_port}}
 
+  defp check_sentinel_endpoints(settings) do
+    settings.sentinel_base_port
+    |> ports_from(settings.sentinels)
+    |> Enum.reduce_while(:ok, fn port, :ok ->
+      case check_port_available(settings.control_host, port) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:sentinel_port_in_use, port, reason}}}
+      end
+    end)
+  end
+
+  defp check_port_available(host, port) do
+    with {:ok, ip} <- :inet.parse_address(to_charlist(host)),
+         {:ok, socket} <-
+           :gen_tcp.listen(port, [
+             :binary,
+             {:ip, ip},
+             {:active, false},
+             {:reuseaddr, true}
+           ]) do
+      :gen_tcp.close(socket)
+      :ok
+    else
+      {:error, :einval} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp ports_from(_base_port, 0), do: []
   defp ports_from(base_port, count), do: Enum.map(0..(count - 1), &(base_port + &1))
+
+  defp replica_port(state, index), do: state.replica_base_port + index
 
   defp format_addr(host, port) do
     if String.contains?(host, ":") do

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -267,9 +267,18 @@ defmodule RedisServerWrapper.Server do
   def handle_info({:EXIT, daemon, reason}, %{daemon: daemon} = state) when is_pid(daemon) do
     # The Forcola.Daemon child exited (redis-server died on its own). Forcola
     # maps the child exit to :normal / {:exit_status, n} / {:exit_signal, n};
-    # translate it into a GenServer stop so an OTP restart strategy behaves.
-    Logger.info("Managed (forcola) redis-server exited: #{inspect(reason)}")
-    {:stop, reason, %{state | daemon: nil, pid: nil}}
+    # translate every unexpected child exit into an abnormal GenServer stop so
+    # both permanent and transient OTP children restart consistently.
+    stop_reason = {:redis_server_exit, :forcola, reason}
+    Logger.warning("Managed (forcola) redis-server exited: #{inspect(reason)}")
+    {:stop, stop_reason, %{state | daemon: nil, pid: nil}}
+  end
+
+  def handle_info({:EXIT, port_ref, reason}, %{port_ref: port_ref} = state)
+      when is_port(port_ref) do
+    stop_reason = {:redis_server_exit, :port, reason}
+    Logger.warning("Managed redis-server port exited: #{inspect(reason)}")
+    {:stop, stop_reason, %{state | port_ref: nil, pid: nil}}
   end
 
   def handle_info({:EXIT, _port, _reason}, state) do
@@ -279,8 +288,9 @@ defmodule RedisServerWrapper.Server do
 
   def handle_info({port_ref, {:exit_status, status}}, %{port_ref: port_ref} = state)
       when is_port(port_ref) do
-    Logger.info("Managed redis-server exited with status #{status}")
-    {:noreply, %{state | port_ref: nil, pid: nil}}
+    stop_reason = {:redis_server_exit, :port, {:exit_status, status}}
+    Logger.warning("Managed redis-server exited with status #{status}")
+    {:stop, stop_reason, %{state | port_ref: nil, pid: nil}}
   end
 
   def handle_info({port_ref, {:data, {:eol, line}}}, %{port_ref: port_ref} = state)
@@ -305,6 +315,12 @@ defmodule RedisServerWrapper.Server do
     )
 
     stop_daemon(daemon)
+    :ok
+  end
+
+  def terminate(_reason, %{managed: managed, daemon: nil, port_ref: nil, pid: nil})
+      when managed in [true, :forcola] do
+    Logger.debug("RedisServerWrapper.Server terminating after managed redis-server exit")
     :ok
   end
 

--- a/test/chaos_test.exs
+++ b/test/chaos_test.exs
@@ -36,17 +36,18 @@ defmodule RedisServerWrapper.ChaosTest do
 
   describe "kill_node/1" do
     test "kills the redis-server OS process" do
-      {:ok, server} = Server.start_link(port: 6450)
+      {:ok, server} = Server.start(port: 6450)
       assert Server.ping(server)
 
       %{pid: os_pid} = Server.info(server)
+      monitor = Process.monitor(server)
       Chaos.kill_node(server)
-      Process.sleep(500)
+
+      assert_receive {:DOWN, ^monitor, :process, ^server, {:redis_server_exit, :port, _}},
+                     5_000
 
       {_, code} = System.cmd("kill", ["-0", to_string(os_pid)], stderr_to_stdout: true)
       assert code != 0
-
-      Server.stop(server)
     end
   end
 
@@ -160,8 +161,7 @@ defmodule RedisServerWrapper.ChaosTest do
       {:ok, killed_pid} = Chaos.kill_master(cluster, "testkey")
       assert is_pid(killed_pid)
 
-      Process.sleep(500)
-      refute Server.alive?(killed_pid)
+      assert wait_until(fn -> not Process.alive?(killed_pid) end, 20, 100)
 
       Cluster.stop(cluster)
       Process.sleep(1000)
@@ -175,8 +175,7 @@ defmodule RedisServerWrapper.ChaosTest do
       {:ok, killed_pid} = Chaos.kill_master(cluster, 0)
       assert is_pid(killed_pid)
 
-      Process.sleep(500)
-      refute Server.alive?(killed_pid)
+      assert wait_until(fn -> not Process.alive?(killed_pid) end, 20, 100)
 
       Cluster.stop(cluster)
       Process.sleep(1000)
@@ -234,9 +233,8 @@ defmodule RedisServerWrapper.ChaosTest do
 
       {:ok, killed_pid} = Chaos.random_kill(cluster)
       assert is_pid(killed_pid)
-      Process.sleep(500)
 
-      refute Server.alive?(killed_pid)
+      assert wait_until(fn -> not Process.alive?(killed_pid) end, 20, 100)
 
       Cluster.stop(cluster)
       Process.sleep(1000)

--- a/test/redis_server_wrapper_test.exs
+++ b/test/redis_server_wrapper_test.exs
@@ -1,7 +1,16 @@
 defmodule RedisServerWrapperTest do
   use ExUnit.Case, async: false
 
-  alias RedisServerWrapper.{Cli, Cluster, Config, Connection, Manager, Sentinel, Server}
+  alias RedisServerWrapper.{
+    Cli,
+    Cluster,
+    Config,
+    Connection,
+    Manager,
+    OSProcess,
+    Sentinel,
+    Server
+  }
 
   setup_all do
     tls_dir =
@@ -35,6 +44,44 @@ defmodule RedisServerWrapperTest do
       {out, 0} -> out |> String.split("\n", trim: true)
       _ -> []
     end
+  end
+
+  defp redis_cli_wrapper!(dir, mode) do
+    path = Path.join(dir, "redis-cli-#{mode}")
+
+    body =
+      case mode do
+        :malformed_cluster_info ->
+          """
+          #!/bin/sh
+          case " $* " in
+            *" CLUSTER INFO "*) printf 'cluster_state:ok\\ncluster_slots_assigned:not-a-number\\n'; exit 0 ;;
+            *) exec redis-cli "$@" ;;
+          esac
+          """
+
+        :malformed_sentinel_master ->
+          """
+          #!/bin/sh
+          case " $* " in
+            *" SENTINEL MASTER "*) printf 'flags\\nmaster\\nnum-slaves\\nnot-a-number\\n'; exit 0 ;;
+            *) exec redis-cli "$@" ;;
+          esac
+          """
+
+        :malformed_replication_info ->
+          """
+          #!/bin/sh
+          case " $* " in
+            *" INFO replication "*) printf 'role:slave\\nmaster_link_status:down\\nmaster_port:bad\\n'; exit 0 ;;
+            *) exec redis-cli "$@" ;;
+          esac
+          """
+      end
+
+    File.write!(path, body)
+    File.chmod!(path, 0o700)
+    path
   end
 
   # -------------------------------------------------------------------
@@ -486,21 +533,50 @@ defmodule RedisServerWrapperTest do
       assert :ok = Server.stop(server)
     end
 
-    test "stopping stale Server state does not stop a replacement listener" do
+    test "managed Server exits when Redis dies and the endpoint can be reused" do
       port = 6416
       {:ok, stale_server} = Server.start(port: port)
       stale_pid = Server.info(stale_server).pid
+      monitor = Process.monitor(stale_server)
+
       assert :ok = RedisServerWrapper.OSProcess.signal(stale_pid, :kill)
-      assert wait_until(fn -> not Server.alive?(stale_server) end, 20, 100)
+
+      assert_receive {:DOWN, ^monitor, :process, ^stale_server, {:redis_server_exit, :port, _}},
+                     5_000
 
       {:ok, replacement_server} = Server.start_link(port: port)
 
       try do
-        assert :ok = Server.stop(stale_server)
         assert Server.ping(replacement_server)
       after
         if Process.alive?(replacement_server), do: Server.stop(replacement_server)
       end
+    end
+
+    test "an OTP supervisor restarts Server after the managed Redis process dies" do
+      port = 6417
+      {:ok, supervisor} = Supervisor.start_link([{Server, [port: port]}], strategy: :one_for_one)
+
+      [{_id, original_server, :worker, _modules}] = Supervisor.which_children(supervisor)
+      original_os_pid = Server.info(original_server).pid
+      assert :ok = RedisServerWrapper.OSProcess.signal(original_os_pid, :kill)
+
+      assert wait_until(
+               fn ->
+                 case Supervisor.which_children(supervisor) do
+                   [{_id, restarted_server, :worker, _modules}]
+                   when is_pid(restarted_server) and restarted_server != original_server ->
+                     Server.ping(restarted_server)
+
+                   _other ->
+                     false
+                 end
+               end,
+               50,
+               100
+             )
+
+      Supervisor.stop(supervisor)
     end
   end
 
@@ -1050,6 +1126,67 @@ defmodule RedisServerWrapperTest do
       end
     end
 
+    test "partial node startup rolls back nodes already started" do
+      base_port = 7465
+      occupied_port = base_port + 1
+      {:ok, existing_server} = Server.start_link(port: occupied_port, save: :disabled)
+
+      try do
+        assert {:error,
+                {:node_start_failed, ^occupied_port, {:port_in_use, ^occupied_port, _reason}}} =
+                 Cluster.start(masters: 3, base_port: base_port)
+
+        refute Cli.ping(Cli.new(port: base_port))
+        assert Server.ping(existing_server)
+      after
+        if Process.alive?(existing_server), do: Server.stop(existing_server)
+      end
+    end
+
+    @tag timeout: 30_000
+    test "a hard-dead cluster node leaves an explicit degraded topology" do
+      {:ok, cluster} = Cluster.start_link(masters: 3, base_port: 7480)
+      assert Cluster.healthy?(cluster)
+
+      [_first, victim | _rest] = Cluster.nodes(cluster)
+      victim_os_pid = Server.info(victim).pid
+      assert :ok = RedisServerWrapper.OSProcess.signal(victim_os_pid, :kill)
+
+      assert wait_until(fn -> not Process.alive?(victim) end, 50, 100)
+      assert Process.alive?(cluster)
+      refute Cluster.all_alive?(cluster)
+      refute Cluster.healthy?(cluster)
+      assert length(Cluster.nodes(cluster)) == 2
+
+      Cluster.stop(cluster)
+    end
+
+    @tag timeout: 30_000
+    test "cluster convergence timeout is actionable and rolls back every node" do
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "redis-server-wrapper-cli-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(temp_dir)
+      cli = redis_cli_wrapper!(temp_dir, :malformed_cluster_info)
+
+      try do
+        assert {:error, {:cluster_convergence_timeout, 200, _last_health}} =
+                 Cluster.start(
+                   masters: 3,
+                   base_port: 7490,
+                   redis_cli_bin: cli,
+                   convergence_timeout: 200
+                 )
+
+        assert Enum.all?(7490..7492, &(not Cli.ping(Cli.new(port: &1))))
+      after
+        File.rm_rf!(temp_dir)
+      end
+    end
+
     @tag timeout: 30_000
     test "start 3-master cluster, verify health, stop" do
       {:ok, cluster} =
@@ -1138,6 +1275,264 @@ defmodule RedisServerWrapperTest do
         assert Server.ping(existing_server)
       after
         if Process.alive?(existing_server), do: Server.stop(existing_server)
+      end
+    end
+
+    @tag timeout: 30_000
+    test "a supervisor restarts Sentinel after a hard-dead control process" do
+      child =
+        {Sentinel,
+         [
+           master_port: 6530,
+           replicas: 0,
+           sentinels: 1,
+           sentinel_base_port: 26_530,
+           quorum: 1
+         ]}
+
+      {:ok, supervisor} = Supervisor.start_link([child], strategy: :one_for_one)
+      [{_id, sentinel, :worker, _modules}] = Supervisor.which_children(supervisor)
+
+      monitor = Process.monitor(sentinel)
+      [control] = :sys.get_state(sentinel).sentinel_processes
+      assert is_pid(control.owner)
+      assert is_integer(control.os_pid)
+      assert :ok = RedisServerWrapper.OSProcess.signal(control.os_pid, :kill)
+
+      assert_receive {:DOWN, ^monitor, :process, ^sentinel,
+                      {:sentinel_control_exit, 26_530, _reason}},
+                     5_000
+
+      assert wait_until(
+               fn ->
+                 case Supervisor.which_children(supervisor) do
+                   [{_id, restarted, :worker, _modules}]
+                   when is_pid(restarted) and restarted != sentinel ->
+                     Sentinel.healthy?(restarted)
+
+                   _other ->
+                     false
+                 end
+               end,
+               50,
+               100
+             )
+
+      Supervisor.stop(supervisor)
+    end
+
+    @tag timeout: 30_000
+    test "a hard-dead Sentinel data node fails and cleans up the topology" do
+      {:ok, sentinel} =
+        Sentinel.start(
+          master_port: 6535,
+          replicas: 1,
+          replica_base_port: 6536,
+          sentinels: 1,
+          sentinel_base_port: 26_535,
+          quorum: 1
+        )
+
+      monitor = Process.monitor(sentinel)
+      [replica] = :sys.get_state(sentinel).replica_pids
+      replica_os_pid = Server.info(replica).pid
+      assert :ok = RedisServerWrapper.OSProcess.signal(replica_os_pid, :kill)
+
+      assert_receive {:DOWN, ^monitor, :process, ^sentinel,
+                      {:sentinel_data_node_exit, :replica, 6536, _reason}},
+                     5_000
+
+      assert wait_until(
+               fn ->
+                 Enum.all?([6535, 6536, 26_535], &(not Cli.ping(Cli.new(port: &1))))
+               end,
+               30,
+               100
+             )
+    end
+
+    @tag timeout: 30_000
+    test "a hard-dead Sentinel master fails the topology coherently" do
+      {:ok, sentinel} =
+        Sentinel.start(
+          master_port: 6565,
+          replicas: 0,
+          sentinels: 1,
+          sentinel_base_port: 26_565,
+          quorum: 1
+        )
+
+      monitor = Process.monitor(sentinel)
+      master = :sys.get_state(sentinel).master_pid
+      master_os_pid = Server.info(master).pid
+      assert :ok = OSProcess.signal(master_os_pid, :kill)
+
+      assert_receive {:DOWN, ^monitor, :process, ^sentinel,
+                      {:sentinel_data_node_exit, :master, 6565, _reason}},
+                     5_000
+
+      assert wait_until(
+               fn ->
+                 not Cli.ping(Cli.new(port: 6565)) and
+                   not Cli.ping(Cli.new(port: 26_565))
+               end,
+               30,
+               100
+             )
+    end
+
+    @tag timeout: 30_000
+    test "Sentinel control processes honor the Forcola backend" do
+      {:ok, sentinel} =
+        Sentinel.start_link(
+          master_port: 6538,
+          replicas: 0,
+          sentinels: 1,
+          sentinel_base_port: 26_538,
+          quorum: 1,
+          managed: :forcola
+        )
+
+      state = :sys.get_state(sentinel)
+      [control] = state.sentinel_processes
+      assert control.managed == :forcola
+      assert Process.alive?(control.owner)
+      assert Sentinel.healthy?(sentinel)
+
+      Sentinel.stop(sentinel)
+      assert wait_until(fn -> not Cli.ping(Cli.new(port: 26_538)) end, 20, 100)
+    end
+
+    @tag timeout: 30_000
+    test "managed false daemonizes Sentinel controls and normal stop reaps them" do
+      {:ok, sentinel} =
+        Sentinel.start_link(
+          master_port: 6545,
+          replicas: 0,
+          sentinels: 1,
+          sentinel_base_port: 26_545,
+          quorum: 1,
+          managed: false
+        )
+
+      [control] = :sys.get_state(sentinel).sentinel_processes
+      assert control.managed == false
+      assert is_nil(control.owner)
+      assert OSProcess.alive?(control.os_pid)
+
+      Sentinel.stop(sentinel)
+
+      assert wait_until(
+               fn ->
+                 not OSProcess.alive?(control.os_pid) and
+                   not Cli.ping(Cli.new(port: 6545))
+               end,
+               30,
+               100
+             )
+    end
+
+    @tag timeout: 30_000
+    test "replication convergence timeout is actionable and rolls back data nodes" do
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "redis-server-wrapper-cli-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(temp_dir)
+      cli = redis_cli_wrapper!(temp_dir, :malformed_replication_info)
+
+      try do
+        assert {:error, {:replication_convergence_timeout, 200, _last_health}} =
+                 Sentinel.start(
+                   master_port: 6550,
+                   replicas: 1,
+                   replica_base_port: 6551,
+                   sentinels: 1,
+                   sentinel_base_port: 26_550,
+                   quorum: 1,
+                   redis_cli_bin: cli,
+                   convergence_timeout: 200
+                 )
+
+        assert Enum.all?([6550, 6551, 26_550], &(not Cli.ping(Cli.new(port: &1))))
+      after
+        File.rm_rf!(temp_dir)
+      end
+    end
+
+    @tag timeout: 30_000
+    test "Sentinel control startup failure rolls back its data node" do
+      fixture_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "redis-server-wrapper-server-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(fixture_dir)
+
+      redis_server =
+        Path.join(fixture_dir, "redis-server-fail-sentinel")
+
+      File.write!(
+        redis_server,
+        """
+        #!/bin/sh
+        for arg in "$@"; do
+          if [ "$arg" = "--sentinel" ]; then
+            exit 42
+          fi
+        done
+        exec redis-server "$@"
+        """
+      )
+
+      File.chmod!(redis_server, 0o700)
+
+      try do
+        assert {:error, {:sentinel_start_failed, 26_560, _reason}} =
+                 Sentinel.start(
+                   master_port: 6560,
+                   replicas: 0,
+                   sentinels: 1,
+                   sentinel_base_port: 26_560,
+                   quorum: 1,
+                   redis_server_bin: redis_server
+                 )
+
+        assert wait_until(fn -> not Cli.ping(Cli.new(port: 6560)) end, 20, 100)
+      after
+        File.rm_rf!(fixture_dir)
+      end
+    end
+
+    @tag timeout: 30_000
+    test "Sentinel convergence timeout handles malformed health and rolls back" do
+      temp_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "redis-server-wrapper-cli-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(temp_dir)
+      cli = redis_cli_wrapper!(temp_dir, :malformed_sentinel_master)
+
+      try do
+        assert {:error, {:sentinel_convergence_timeout, 200, _last_health}} =
+                 Sentinel.start(
+                   master_port: 6540,
+                   replicas: 0,
+                   sentinels: 1,
+                   sentinel_base_port: 26_540,
+                   quorum: 1,
+                   redis_cli_bin: cli,
+                   convergence_timeout: 200
+                 )
+
+        assert Enum.all?([6540, 26_540], &(not Cli.ping(Cli.new(port: &1))))
+      after
+        File.rm_rf!(temp_dir)
       end
     end
 

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -1,7 +1,16 @@
 defmodule RedisServerWrapperUnitTest do
   use ExUnit.Case, async: false
 
-  alias RedisServerWrapper.{Cli, Cluster, Connection, OSProcess, SecureFile, Sentinel, Server}
+  alias RedisServerWrapper.{
+    Cli,
+    Cluster,
+    Connection,
+    ManagedProcess,
+    OSProcess,
+    SecureFile,
+    Sentinel,
+    Server
+  }
 
   setup do
     fixture_dir =
@@ -428,6 +437,10 @@ defmodule RedisServerWrapperUnitTest do
              Cluster.start(replicas_per_master: -1)
 
     assert {:error, {:invalid_option, :timeout, 0}} = Cluster.start(timeout: 0)
+
+    assert {:error, {:invalid_option, :convergence_timeout, 0}} =
+             Cluster.start(convergence_timeout: 0)
+
     assert {:error, {:invalid_option, :base_port, 0}} = Cluster.start(base_port: 0)
 
     assert {:error, {:unsupported_transport, :cluster, :unix}} =
@@ -455,6 +468,10 @@ defmodule RedisServerWrapperUnitTest do
     assert {:error, {:invalid_option, :sentinels, 0}} = Sentinel.start(sentinels: 0)
     assert {:error, {:invalid_quorum, 4, 3}} = Sentinel.start(quorum: 4)
     assert {:error, {:invalid_option, :timeout, 0}} = Sentinel.start(timeout: 0)
+
+    assert {:error, {:invalid_option, :convergence_timeout, 0}} =
+             Sentinel.start(convergence_timeout: 0)
+
     assert {:error, {:invalid_option, :master_port, "bad"}} = Sentinel.start(master_port: "bad")
 
     assert {:error, {:unsupported_transport, :sentinel, :unix}} =
@@ -483,6 +500,122 @@ defmodule RedisServerWrapperUnitTest do
                sentinel_base_port: 6391,
                quorum: 1
              )
+  end
+
+  test "managed process validates backend, executable, and argv" do
+    common = [ready: fn -> true end, ready_timeout_ms: 100]
+    previous_trap_exit = Process.flag(:trap_exit, true)
+
+    try do
+      assert {:error, {:invalid_managed, :unknown}} =
+               ManagedProcess.start_link(
+                 common ++ [backend: :unknown, argv: ["/bin/sh", "-c", "exit 0"]]
+               )
+
+      assert {:error, {:executable_not_found, "missing-managed-process"}} =
+               ManagedProcess.start_link(
+                 common ++ [backend: true, argv: ["missing-managed-process"]]
+               )
+
+      assert {:error, {:invalid_argv, []}} =
+               ManagedProcess.start_link(common ++ [backend: true, argv: []])
+    after
+      Process.flag(:trap_exit, previous_trap_exit)
+    end
+  end
+
+  test "managed Port process reports info and tolerates a raising shutdown callback", %{
+    fixture_dir: fixture_dir
+  } do
+    script =
+      write_executable(
+        fixture_dir,
+        "long-running-process",
+        "#!/bin/sh\necho started\nwhile :; do sleep 1; done\n"
+      )
+
+    test_pid = self()
+
+    {:ok, process} =
+      ManagedProcess.start_link(
+        backend: true,
+        argv: [script],
+        ready: fn -> true end,
+        ready_timeout_ms: 1_000,
+        label: "unit managed process",
+        shutdown: fn ->
+          send(test_pid, :shutdown_called)
+          raise "ignored shutdown failure"
+        end
+      )
+
+    assert %{backend: true, pid: os_pid} = ManagedProcess.info(process)
+    assert is_integer(os_pid)
+    assert :ok = ManagedProcess.stop(process)
+    assert_receive :shutdown_called
+    refute OSProcess.alive?(os_pid)
+  end
+
+  test "managed Port process reports readiness timeout and early exit", %{
+    fixture_dir: fixture_dir
+  } do
+    sleeper = write_executable(fixture_dir, "sleeping-process", "#!/bin/sh\nsleep 5\n")
+    exiting = write_executable(fixture_dir, "exiting-process", "#!/bin/sh\nexit 7\n")
+    previous_trap_exit = Process.flag(:trap_exit, true)
+
+    try do
+      assert {:error, {:managed_process_start_failed, "timeout", :ready_timeout}} =
+               ManagedProcess.start_link(
+                 backend: true,
+                 argv: [sleeper],
+                 ready: fn -> false end,
+                 ready_timeout_ms: 20,
+                 label: "timeout"
+               )
+
+      assert {:error, {:managed_process_start_failed, "early-exit", :exited_before_ready}} =
+               ManagedProcess.start_link(
+                 backend: true,
+                 argv: [exiting],
+                 ready: fn -> false end,
+                 ready_timeout_ms: 1_000,
+                 label: "early-exit"
+               )
+    after
+      Process.flag(:trap_exit, previous_trap_exit)
+    end
+  end
+
+  test "managed Forcola process translates child exit into its lifecycle reason", %{
+    fixture_dir: fixture_dir
+  } do
+    script =
+      write_executable(
+        fixture_dir,
+        "forcola-exiting-process",
+        "#!/bin/sh\nsleep 1\nexit 7\n"
+      )
+
+    previous_trap_exit = Process.flag(:trap_exit, true)
+
+    try do
+      {:ok, process} =
+        ManagedProcess.start_link(
+          backend: :forcola,
+          argv: [script],
+          ready: fn -> true end,
+          ready_timeout_ms: 1_000,
+          label: "forcola-test"
+        )
+
+      monitor = Process.monitor(process)
+
+      assert_receive {:DOWN, ^monitor, :process, ^process,
+                      {:managed_process_exit, "forcola-test", :forcola, _reason}},
+                     5_000
+    after
+      Process.flag(:trap_exit, previous_trap_exit)
+    end
   end
 
   defp write_executable(dir, name, contents) do


### PR DESCRIPTION
## Summary

- make managed `Server` processes exit abnormally when their Redis child dies, with consistent Port and Forcola reasons so OTP supervisors restart them
- make Cluster child loss explicit by removing the dead node, retaining the topology for failover/chaos work, and reporting degraded health
- manage Sentinel control processes with the selected `managed` backend and fail/restart the complete topology on master, replica, or control-process loss
- replace Cluster, replication, and Sentinel startup sleeps with bounded convergence polling and diagnostic timeout errors
- make Cluster/Sentinel health parsing total and strengthen Cluster health across every node
- roll back partial node, replication, control-process, and convergence failures without leaving listeners behind

## Lifecycle contract

- `Server`: unexpected managed child exit stops with `{:redis_server_exit, backend, reason}`
- `Cluster`: dead node is removed; topology stays alive but `all_alive?/1` and `healthy?/1` return false
- `Sentinel`: any managed data/control child loss stops and cleans up the topology so a supervisor can rebuild it coherently
- `managed: false`: Sentinel controls retain daemonized semantics for detachable topologies

## Validation

- 104 tests pass
- 90.26% line coverage
- Redis-backed hard-death, supervisor restart, degraded topology, partial rollback, malformed health, TLS, Forcola, and unmanaged cleanup tests
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`
- `mix hex.build`

Closes #59
