### PR TITLE
Harden chaos operations and cluster parsing

### DIFF
--- a/lib/redis_server_wrapper/chaos.ex
+++ b/lib/redis_server_wrapper/chaos.ex
@@ -37,7 +37,9 @@ defmodule RedisServerWrapper.Chaos do
       Chaos.recover(frozen_os_pids)
   """
 
-  alias RedisServerWrapper.{Cluster, Server}
+  alias RedisServerWrapper.{Cluster, OSProcess, Server}
+
+  require Logger
 
   # -------------------------------------------------------------------
   # Node-level operations
@@ -46,14 +48,13 @@ defmodule RedisServerWrapper.Chaos do
   @doc """
   Sends SIGKILL to a server's redis-server OS process.
 
-  The process is killed immediately and cannot be recovered.
-  The GenServer will still be alive but the underlying redis-server will be dead.
+  The process is killed immediately and cannot be recovered. Managed `Server`
+  processes exit after observing the child death.
   """
-  @spec kill_node(GenServer.server()) :: :ok
+  @spec kill_node(GenServer.server()) :: :ok | {:error, term()}
   def kill_node(server) do
-    %{pid: os_pid} = Server.info(server)
-    System.cmd("kill", ["-9", to_string(os_pid)], stderr_to_stdout: true)
-    :ok
+    with {:ok, os_pid} <- server_os_pid(server),
+         do: OSProcess.signal(os_pid, :kill)
   end
 
   @doc """
@@ -62,18 +63,19 @@ defmodule RedisServerWrapper.Chaos do
   The node will be completely unresponsive for the duration, simulating a process freeze
   or a very long GC pause. Returns `{:ok, os_pid}` with the OS process ID.
   """
-  @spec pause_node(GenServer.server(), non_neg_integer()) :: {:ok, non_neg_integer()}
-  def pause_node(server, duration_ms) do
-    %{pid: os_pid} = Server.info(server)
-    System.cmd("kill", ["-STOP", to_string(os_pid)], stderr_to_stdout: true)
-
-    spawn(fn ->
-      Process.sleep(duration_ms)
-      System.cmd("kill", ["-CONT", to_string(os_pid)], stderr_to_stdout: true)
-    end)
-
-    {:ok, os_pid}
+  @spec pause_node(GenServer.server(), non_neg_integer()) ::
+          {:ok, pos_integer()} | {:error, term()}
+  def pause_node(server, duration_ms)
+      when is_integer(duration_ms) and duration_ms >= 0 do
+    with {:ok, os_pid} <- server_os_pid(server),
+         :ok <- OSProcess.signal(os_pid, :stop) do
+      spawn(fn -> resume_after(os_pid, duration_ms) end)
+      {:ok, os_pid}
+    end
   end
+
+  def pause_node(_server, duration_ms),
+    do: {:error, {:invalid_duration, duration_ms}}
 
   @doc """
   Sends SIGSTOP to freeze a node indefinitely.
@@ -82,11 +84,12 @@ defmodule RedisServerWrapper.Chaos do
   `resume_node/1` to unfreeze. The OS pid is needed because the Server GenServer
   will be blocked while the redis-server process is frozen.
   """
-  @spec freeze_node(GenServer.server()) :: {:ok, non_neg_integer()}
+  @spec freeze_node(GenServer.server()) :: {:ok, pos_integer()} | {:error, term()}
   def freeze_node(server) do
-    %{pid: os_pid} = Server.info(server)
-    System.cmd("kill", ["-STOP", to_string(os_pid)], stderr_to_stdout: true)
-    {:ok, os_pid}
+    with {:ok, os_pid} <- server_os_pid(server),
+         :ok <- OSProcess.signal(os_pid, :stop) do
+      {:ok, os_pid}
+    end
   end
 
   @doc """
@@ -94,11 +97,11 @@ defmodule RedisServerWrapper.Chaos do
 
   Accepts an OS pid (integer) as returned by `freeze_node/1` or `partition/2`.
   """
-  @spec resume_node(non_neg_integer()) :: :ok
-  def resume_node(os_pid) when is_integer(os_pid) do
-    System.cmd("kill", ["-CONT", to_string(os_pid)], stderr_to_stdout: true)
-    :ok
-  end
+  @spec resume_node(pos_integer()) :: :ok | {:error, term()}
+  def resume_node(os_pid) when is_integer(os_pid) and os_pid > 0,
+    do: OSProcess.signal(os_pid, :cont)
+
+  def resume_node(os_pid), do: {:error, {:invalid_os_pid, os_pid}}
 
   @doc """
   Pauses all client connections for `duration_ms` using Redis CLIENT PAUSE.
@@ -125,16 +128,23 @@ defmodule RedisServerWrapper.Chaos do
 
   Useful for testing memory pressure, eviction policies, and OOM behavior.
   """
-  @spec fill_memory(GenServer.server(), non_neg_integer()) :: :ok
-  def fill_memory(server, key_count \\ 10_000) do
+  @spec fill_memory(GenServer.server(), non_neg_integer()) :: :ok | {:error, term()}
+  def fill_memory(server, key_count \\ 10_000)
+  def fill_memory(_server, 0), do: :ok
+
+  def fill_memory(server, key_count) when is_integer(key_count) and key_count > 0 do
     value = String.duplicate("x", 1024)
 
-    Enum.each(1..key_count, fn i ->
-      Server.run(server, ["SET", "chaos:fill:#{i}", value])
+    Enum.reduce_while(1..key_count, :ok, fn i, :ok ->
+      case safe_server_run(server, ["SET", "chaos:fill:#{i}", value]) do
+        {:ok, _reply} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:fill_failed, i, reason}}}
+      end
     end)
-
-    :ok
   end
+
+  def fill_memory(_server, key_count),
+    do: {:error, {:invalid_key_count, key_count}}
 
   @doc """
   Triggers a background save (BGSAVE) on the node.
@@ -167,22 +177,26 @@ defmodule RedisServerWrapper.Chaos do
   @spec kill_master(GenServer.server(), String.t() | non_neg_integer()) ::
           {:ok, pid()} | {:error, term()}
   def kill_master(cluster, key) when is_binary(key) do
-    case Cluster.run(cluster, ["CLUSTER", "KEYSLOT", key]) do
-      {:ok, slot_str} -> kill_master(cluster, String.to_integer(slot_str))
-      {:error, reason} -> {:error, {:keyslot_failed, reason}}
+    case safe_cluster_run(cluster, ["CLUSTER", "KEYSLOT", key]) do
+      {:ok, slot_str} ->
+        case parse_integer(slot_str) do
+          {:ok, slot} -> kill_master(cluster, slot)
+          :error -> {:error, {:invalid_keyslot_reply, slot_str}}
+        end
+
+      {:error, reason} ->
+        {:error, {:keyslot_failed, reason}}
     end
   end
 
-  def kill_master(cluster, slot) when is_integer(slot) do
-    case find_master_for_slot(cluster, slot) do
-      {:ok, server_pid} ->
-        kill_node(server_pid)
-        {:ok, server_pid}
-
-      {:error, _} = error ->
-        error
+  def kill_master(cluster, slot) when is_integer(slot) and slot in 0..16_383 do
+    with {:ok, server_pid} <- find_master_for_slot(cluster, slot),
+         :ok <- kill_node(server_pid) do
+      {:ok, server_pid}
     end
   end
+
+  def kill_master(_cluster, slot), do: {:error, {:invalid_slot, slot}}
 
   @doc """
   Simulates a network partition by freezing (SIGSTOP) all nodes not in the first group.
@@ -202,27 +216,29 @@ defmodule RedisServerWrapper.Chaos do
       # Later...
       Chaos.recover(frozen_os_pids)
   """
-  @spec partition(GenServer.server(), [[pid()]]) :: {:ok, [non_neg_integer()]}
-  def partition(_cluster, [_active | frozen_groups]) do
-    os_pids =
-      frozen_groups
-      |> List.flatten()
-      |> Enum.map(fn server ->
-        {:ok, os_pid} = freeze_node(server)
-        os_pid
-      end)
-
-    {:ok, os_pids}
+  @spec partition(GenServer.server(), [[pid()]]) ::
+          {:ok, [pos_integer()]} | {:error, term()}
+  def partition(cluster, groups) do
+    with {:ok, cluster_nodes} <- cluster_nodes(cluster),
+         :ok <- validate_partition_groups(cluster_nodes, groups) do
+      [_active | frozen_groups] = groups
+      freeze_partition_nodes(List.flatten(frozen_groups))
+    end
   end
 
   @doc """
   Kills a random node in the cluster. Returns `{:ok, server_pid}` of the killed node.
   """
-  @spec random_kill(GenServer.server()) :: {:ok, pid()}
+  @spec random_kill(GenServer.server()) :: {:ok, pid()} | {:error, term()}
   def random_kill(cluster) do
-    node = cluster |> Cluster.nodes() |> Enum.random()
-    kill_node(node)
-    {:ok, node}
+    with {:ok, [_node | _rest] = nodes} <- cluster_nodes(cluster),
+         selected = Enum.random(nodes),
+         :ok <- kill_node(selected) do
+      {:ok, selected}
+    else
+      {:ok, []} -> {:error, :empty_cluster}
+      {:error, _reason} = error -> error
+    end
   end
 
   @doc """
@@ -266,59 +282,102 @@ defmodule RedisServerWrapper.Chaos do
   Recovers frozen nodes by sending SIGCONT to each OS pid.
 
   Accepts a list of OS pids as returned by `freeze_node/1` or `partition/2`.
-  Nodes that were killed (not just frozen) are silently skipped.
+  Returns a structured error containing every PID that could not be resumed.
   """
-  @spec recover([non_neg_integer()]) :: :ok
+  @spec recover(term()) :: :ok | {:error, [{term(), term()}]}
   def recover(os_pids) when is_list(os_pids) do
-    Enum.each(os_pids, &resume_node/1)
-    :ok
+    failures =
+      Enum.flat_map(os_pids, fn os_pid ->
+        case resume_node(os_pid) do
+          :ok -> []
+          {:error, reason} -> [{os_pid, reason}]
+        end
+      end)
+
+    if failures == [], do: :ok, else: {:error, failures}
   end
+
+  def recover(other), do: {:error, [{other, :invalid_pid_list}]}
 
   # -------------------------------------------------------------------
   # Internal helpers
   # -------------------------------------------------------------------
 
-  defp find_master_for_slot(cluster, target_slot) do
-    node_pids = Cluster.nodes(cluster)
+  defp resume_after(os_pid, duration_ms) do
+    Process.sleep(duration_ms)
 
-    # Get CLUSTER NODES output from any responsive node
-    cluster_nodes_output =
-      Enum.find_value(node_pids, fn pid ->
-        case Server.run(pid, ["CLUSTER", "NODES"]) do
-          {:ok, output} -> output
-          _ -> nil
-        end
-      end)
+    case OSProcess.signal(os_pid, :cont) do
+      :ok ->
+        :ok
 
-    with output when not is_nil(output) <- cluster_nodes_output,
-         {:ok, {host, port}} <- find_master_addr_for_slot(output, target_slot) do
-      match_master_pid(node_pids, host, port)
-    else
-      nil -> {:error, :no_responsive_nodes}
-      {:error, _} = error -> error
+      {:error, reason} ->
+        Logger.warning("Unable to resume paused Redis process #{os_pid}: #{inspect(reason)}")
     end
   end
 
-  defp match_master_pid(node_pids, host, port) do
-    match =
-      Enum.find(node_pids, fn pid ->
-        info = Server.info(pid)
-        info.host == host && info.port == port
-      end)
-
-    if match, do: {:ok, match}, else: {:error, :master_pid_not_found}
+  defp find_master_for_slot(cluster, target_slot) do
+    with {:ok, node_pids} <- cluster_nodes(cluster),
+         :ok <- ensure_non_empty_cluster(node_pids) do
+      find_master_from_nodes(node_pids, target_slot)
+    end
   end
 
-  defp find_master_addr_for_slot(cluster_nodes_output, target_slot) do
+  defp find_master_from_nodes(node_pids, target_slot) do
+    cluster_nodes_output =
+      Enum.find_value(node_pids, fn pid ->
+        case safe_server_run(pid, ["CLUSTER", "NODES"]) do
+          {:ok, output} -> output
+          _other -> nil
+        end
+      end)
+
+    with output when is_binary(output) <- cluster_nodes_output,
+         {:ok, {host, port}} <- master_addr_for_slot(output, target_slot) do
+      match_master_pid(node_pids, host, port)
+    else
+      nil -> {:error, :no_responsive_nodes}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp ensure_non_empty_cluster([]), do: {:error, :empty_cluster}
+  defp ensure_non_empty_cluster([_node | _rest]), do: :ok
+
+  defp match_master_pid(node_pids, host, port) do
+    infos =
+      Enum.flat_map(node_pids, fn pid ->
+        case safe_server_info(pid) do
+          {:ok, info} -> [{pid, info}]
+          {:error, _reason} -> []
+        end
+      end)
+
+    match =
+      Enum.find(infos, fn {_pid, info} -> info.host == host && info.port == port end) ||
+        Enum.find(infos, fn {_pid, info} -> info.port == port end)
+
+    case match do
+      {pid, _info} -> {:ok, pid}
+      nil -> {:error, {:master_pid_not_found, host, port}}
+    end
+  end
+
+  @doc false
+  @spec master_addr_for_slot(String.t(), integer()) ::
+          {:ok, {String.t(), :inet.port_number()}} | {:error, term()}
+  def master_addr_for_slot(cluster_nodes_output, target_slot)
+      when is_binary(cluster_nodes_output) and target_slot in 0..16_383 do
     master =
       cluster_nodes_output
       |> String.split("\n", trim: true)
       |> Enum.find(fn line ->
-        parts = String.split(line)
-        # parts: [id, addr, flags, master_id, ping, pong, epoch, state, ...slots]
-        length(parts) >= 9 &&
-          String.contains?(Enum.at(parts, 2), "master") &&
-          slot_ranges_contain?(Enum.drop(parts, 8), target_slot)
+        case String.split(line) do
+          [_id, _address, flags, _master_id, _ping, _pong, _epoch, _state | slots] ->
+            master_flags?(flags) && slot_ranges_contain?(slots, target_slot)
+
+          _other ->
+            false
+        end
       end)
 
     case master do
@@ -326,11 +385,65 @@ defmodule RedisServerWrapper.Chaos do
         {:error, {:slot_not_found, target_slot}}
 
       line ->
-        # Address format: "127.0.0.1:7000@17000" or "127.0.0.1:7000@17000,hostname"
-        addr_part = line |> String.split() |> Enum.at(1)
-        [host_port | _] = String.split(addr_part, "@")
-        [host, port_str] = String.split(host_port, ":")
-        {:ok, {host, String.to_integer(port_str)}}
+        [_id, address | _rest] = String.split(line)
+        parse_node_address(address)
+    end
+  end
+
+  def master_addr_for_slot(_cluster_nodes_output, target_slot),
+    do: {:error, {:invalid_slot, target_slot}}
+
+  defp master_flags?(flags) do
+    flags = String.split(flags, ",")
+
+    "master" in flags &&
+      Enum.all?(["fail", "fail?", "handshake", "noaddr"], &(&1 not in flags))
+  end
+
+  defp parse_node_address(address) do
+    endpoint =
+      address
+      |> String.split(",", parts: 2)
+      |> hd()
+      |> String.split("@", parts: 2)
+      |> hd()
+
+    case endpoint do
+      "[" <> _rest ->
+        parse_bracketed_address(endpoint, address)
+
+      _other ->
+        parse_unbracketed_address(endpoint, address)
+    end
+  end
+
+  defp parse_bracketed_address(endpoint, original) do
+    case Regex.run(~r/^\[(.+)\]:(\d+)$/, endpoint, capture: :all_but_first) do
+      [host, port] -> valid_node_address(host, port, original)
+      _other -> {:error, {:invalid_node_address, original}}
+    end
+  end
+
+  defp parse_unbracketed_address(endpoint, original) do
+    case :binary.matches(endpoint, ":") do
+      [] ->
+        {:error, {:invalid_node_address, original}}
+
+      matches ->
+        {separator, 1} = List.last(matches)
+        host = binary_part(endpoint, 0, separator)
+        port = binary_part(endpoint, separator + 1, byte_size(endpoint) - separator - 1)
+        valid_node_address(host, port, original)
+    end
+  end
+
+  defp valid_node_address("", _port, original),
+    do: {:error, {:invalid_node_address, original}}
+
+  defp valid_node_address(host, port, original) do
+    case parse_integer(port) do
+      {:ok, parsed_port} when parsed_port in 1..65_535 -> {:ok, {host, parsed_port}}
+      _other -> {:error, {:invalid_node_address, original}}
     end
   end
 
@@ -338,14 +451,153 @@ defmodule RedisServerWrapper.Chaos do
     Enum.any?(slot_parts, &slot_range_match?(&1, target_slot))
   end
 
+  # Migrating/importing markers such as [1234->-node-id] describe transitional
+  # state, not ownership. Only stable single slots and ranges are considered.
+  defp slot_range_match?("[" <> _transition, _target_slot), do: false
+
   defp slot_range_match?(part, target_slot) do
-    case String.split(part, "-") do
-      [start_str, end_str] ->
-        target_slot >= String.to_integer(start_str) &&
-          target_slot <= String.to_integer(end_str)
+    case String.split(part, "-", parts: 2) do
+      [start_value, end_value] ->
+        with {:ok, start_slot} <- parse_slot(start_value),
+             {:ok, end_slot} <- parse_slot(end_value) do
+          start_slot <= end_slot &&
+            target_slot >= start_slot &&
+            target_slot <= end_slot
+        else
+          :error -> false
+        end
 
       [single] ->
-        match?({^target_slot, ""}, Integer.parse(single))
+        match?({:ok, ^target_slot}, parse_slot(single))
+    end
+  end
+
+  defp parse_slot(value) do
+    case parse_integer(value) do
+      {:ok, slot} when slot in 0..16_383 -> {:ok, slot}
+      _other -> :error
+    end
+  end
+
+  defp parse_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {integer, ""} -> {:ok, integer}
+      _other -> :error
+    end
+  end
+
+  defp parse_integer(_value), do: :error
+
+  defp server_os_pid(server) do
+    with {:ok, info} <- safe_server_info(server),
+         {:ok, os_pid} <- fetch_server_os_pid(info) do
+      validate_server_os_pid(os_pid)
+    end
+  end
+
+  defp fetch_server_os_pid(info) do
+    case Map.fetch(info, :pid) do
+      {:ok, os_pid} -> {:ok, os_pid}
+      :error -> {:error, {:invalid_server_info, info}}
+    end
+  end
+
+  defp validate_server_os_pid(nil), do: {:error, :missing_os_pid}
+
+  defp validate_server_os_pid(os_pid) when is_integer(os_pid) and os_pid > 0 do
+    cond do
+      not OSProcess.available?("kill") -> {:error, {:executable_not_found, "kill"}}
+      OSProcess.alive?(os_pid) -> {:ok, os_pid}
+      true -> {:error, {:process_not_alive, os_pid}}
+    end
+  end
+
+  defp validate_server_os_pid(os_pid), do: {:error, {:invalid_os_pid, os_pid}}
+
+  defp safe_server_info(server) do
+    {:ok, Server.info(server)}
+  catch
+    :exit, reason -> {:error, {:server_unavailable, reason}}
+  end
+
+  defp safe_server_run(server, command) do
+    Server.run(server, command)
+  catch
+    :exit, reason -> {:error, {:server_unavailable, reason}}
+  end
+
+  defp safe_cluster_run(cluster, command) do
+    Cluster.run(cluster, command)
+  catch
+    :exit, reason -> {:error, {:cluster_unavailable, reason}}
+  end
+
+  defp cluster_nodes(cluster) do
+    {:ok, Cluster.nodes(cluster)}
+  catch
+    :exit, reason -> {:error, {:cluster_unavailable, reason}}
+  end
+
+  defp validate_partition_groups([], _groups), do: {:error, :empty_cluster}
+  defp validate_partition_groups(_cluster_nodes, []), do: {:error, :empty_groups}
+
+  defp validate_partition_groups(cluster_nodes, groups) when is_list(groups) do
+    with :ok <- validate_non_empty_groups(groups),
+         :ok <- validate_group_members(groups) do
+      members = List.flatten(groups)
+      unique_members = MapSet.new(members)
+
+      cond do
+        length(members) != MapSet.size(unique_members) ->
+          {:error, :duplicate_partition_members}
+
+        unique_members != MapSet.new(cluster_nodes) ->
+          {:error, {:partition_membership_mismatch, cluster_nodes, members}}
+
+        true ->
+          :ok
+      end
+    end
+  end
+
+  defp validate_partition_groups(_cluster_nodes, groups),
+    do: {:error, {:invalid_groups, groups}}
+
+  defp validate_non_empty_groups(groups) do
+    case Enum.find_index(groups, &(not is_list(&1) or &1 == [])) do
+      nil -> :ok
+      index -> {:error, {:empty_or_invalid_group, index}}
+    end
+  end
+
+  defp validate_group_members(groups) do
+    case Enum.find_value(Enum.with_index(groups), &invalid_group_member/1) do
+      nil -> :ok
+      {group_index, member} -> {:error, {:invalid_group_member, group_index, member}}
+    end
+  end
+
+  defp invalid_group_member({group, group_index}) do
+    case Enum.find(group, &(not is_pid(&1))) do
+      nil -> nil
+      member -> {group_index, member}
+    end
+  end
+
+  defp freeze_partition_nodes(nodes) do
+    Enum.reduce_while(nodes, {:ok, []}, fn server, {:ok, frozen_os_pids} ->
+      case freeze_node(server) do
+        {:ok, os_pid} ->
+          {:cont, {:ok, [os_pid | frozen_os_pids]}}
+
+        {:error, reason} ->
+          recovery = recover(frozen_os_pids)
+          {:halt, {:error, {:partition_failed, server, reason, recovery}}}
+      end
+    end)
+    |> case do
+      {:ok, os_pids} -> {:ok, Enum.reverse(os_pids)}
+      {:error, _reason} = error -> error
     end
   end
 end

--- a/test/chaos_test.exs
+++ b/test/chaos_test.exs
@@ -41,7 +41,7 @@ defmodule RedisServerWrapper.ChaosTest do
 
       %{pid: os_pid} = Server.info(server)
       monitor = Process.monitor(server)
-      Chaos.kill_node(server)
+      assert :ok = Chaos.kill_node(server)
 
       assert_receive {:DOWN, ^monitor, :process, ^server, {:redis_server_exit, :port, _}},
                      5_000
@@ -63,7 +63,7 @@ defmodule RedisServerWrapper.ChaosTest do
       assert process_stopped?(os_pid)
 
       # Resume and verify it responds again
-      Chaos.resume_node(os_pid)
+      assert :ok = Chaos.resume_node(os_pid)
       assert wait_until(fn -> direct_ping(6451) end, 5, 500)
 
       Server.stop(server)
@@ -126,7 +126,7 @@ defmodule RedisServerWrapper.ChaosTest do
     test "fills node with dummy keys" do
       {:ok, server} = Server.start_link(port: 6455)
 
-      Chaos.fill_memory(server, 100)
+      assert :ok = Chaos.fill_memory(server, 100)
 
       {:ok, count} = Server.run(server, ["DBSIZE"])
       assert String.to_integer(count) == 100
@@ -214,7 +214,7 @@ defmodule RedisServerWrapper.ChaosTest do
       end)
 
       # Recover using returned OS pids
-      Chaos.recover(frozen_os_pids)
+      assert :ok = Chaos.recover(frozen_os_pids)
 
       # Wait for all nodes to become responsive
       all_ports = active_ports ++ Enum.map(frozen_info, &elem(&1, 0))
@@ -342,7 +342,7 @@ defmodule RedisServerWrapper.ChaosTest do
       end)
 
       # Recover all
-      Chaos.recover(os_pids)
+      assert :ok = Chaos.recover(os_pids)
 
       # Wait for all nodes to become responsive
       assert wait_until(fn -> Enum.all?(ports, &direct_ping/1) end, 10, 1000)

--- a/test/redis_server_wrapper_unit_test.exs
+++ b/test/redis_server_wrapper_unit_test.exs
@@ -2,6 +2,7 @@ defmodule RedisServerWrapperUnitTest do
   use ExUnit.Case, async: false
 
   alias RedisServerWrapper.{
+    Chaos,
     Cli,
     Cluster,
     Connection,
@@ -11,6 +12,26 @@ defmodule RedisServerWrapperUnitTest do
     Sentinel,
     Server
   }
+
+  defmodule FakeEndpoint do
+    use GenServer
+
+    def start_link(replies), do: GenServer.start_link(__MODULE__, replies)
+
+    @impl true
+    def init(replies), do: {:ok, replies}
+
+    @impl true
+    def handle_call(request, _from, replies) do
+      reply =
+        case Map.fetch(replies, request) do
+          {:ok, reply} -> reply
+          :error when is_tuple(request) -> Map.fetch!(replies, elem(request, 0))
+        end
+
+      {:reply, reply, replies}
+    end
+  end
 
   setup do
     fixture_dir =
@@ -204,6 +225,138 @@ defmodule RedisServerWrapperUnitTest do
 
     assert {:error, "sentinel-error"} =
              Cli.sentinel_master(Cli.new(bin: bin, host: "error"), "mymaster")
+  end
+
+  test "chaos memory fill validates counts without issuing zero writes" do
+    assert :ok = Chaos.fill_memory(self(), 0)
+    assert {:error, {:invalid_key_count, -1}} = Chaos.fill_memory(self(), -1)
+    assert {:error, {:invalid_key_count, 1.5}} = Chaos.fill_memory(self(), 1.5)
+    assert {:error, {:invalid_duration, -1}} = Chaos.pause_node(self(), -1)
+
+    {:ok, failing_server} = FakeEndpoint.start_link(%{run: {:error, "write failed"}})
+
+    assert {:error, {:fill_failed, 1, "write failed"}} =
+             Chaos.fill_memory(failing_server)
+  end
+
+  test "chaos node signals report missing, dead, invalid, and unavailable processes" do
+    {:ok, missing_pid_server} = FakeEndpoint.start_link(%{info: %{pid: nil}})
+    {:ok, dead_pid_server} = FakeEndpoint.start_link(%{info: %{pid: 2_147_483_647}})
+    {:ok, absent_pid_server} = FakeEndpoint.start_link(%{info: %{}})
+
+    assert {:error, :missing_os_pid} = Chaos.kill_node(missing_pid_server)
+
+    assert {:error, {:process_not_alive, 2_147_483_647}} =
+             Chaos.freeze_node(dead_pid_server)
+
+    assert {:error, {:invalid_server_info, %{}}} = Chaos.kill_node(absent_pid_server)
+    assert {:error, {:invalid_os_pid, 0}} = Chaos.resume_node(0)
+    assert {:error, [{0, {:invalid_os_pid, 0}}]} = Chaos.recover([0])
+    assert {:error, [{:not_a_list, :invalid_pid_list}]} = Chaos.recover(:not_a_list)
+
+    {:ok, stopped_server} = FakeEndpoint.start_link(%{info: %{pid: nil}})
+    GenServer.stop(stopped_server)
+
+    assert {:error, {:server_unavailable, _reason}} = Chaos.kill_node(stopped_server)
+
+    original_path = System.get_env("PATH")
+
+    {:ok, current_pid_server} =
+      FakeEndpoint.start_link(%{info: %{pid: System.pid() |> String.to_integer()}})
+
+    System.put_env("PATH", "")
+
+    try do
+      assert {:error, {:executable_not_found, "kill"}} =
+               Chaos.resume_node(System.pid() |> String.to_integer())
+
+      assert {:error, {:executable_not_found, "kill"}} =
+               Chaos.kill_node(current_pid_server)
+    after
+      restore_path(original_path)
+    end
+  end
+
+  test "chaos cluster operations reject empty and invalid partitions safely" do
+    {:ok, empty_cluster} = FakeEndpoint.start_link(%{nodes: []})
+
+    assert {:error, :empty_cluster} = Chaos.random_kill(empty_cluster)
+    assert {:error, :empty_cluster} = Chaos.partition(empty_cluster, [[]])
+
+    {:ok, cluster} = FakeEndpoint.start_link(%{nodes: [self()]})
+
+    assert {:error, :empty_groups} = Chaos.partition(cluster, [])
+    assert {:error, {:invalid_groups, :invalid}} = Chaos.partition(cluster, :invalid)
+    assert {:error, {:empty_or_invalid_group, 0}} = Chaos.partition(cluster, [[]])
+
+    assert {:error, {:invalid_group_member, 0, :not_a_pid}} =
+             Chaos.partition(cluster, [[:not_a_pid]])
+
+    assert {:error, :duplicate_partition_members} =
+             Chaos.partition(cluster, [[self(), self()]])
+
+    assert {:error, {:partition_membership_mismatch, [expected], [actual]}} =
+             Chaos.partition(cluster, [[cluster]])
+
+    assert expected == self()
+    assert actual == cluster
+    assert {:error, {:invalid_slot, -1}} = Chaos.kill_master(cluster, -1)
+    assert {:error, {:invalid_slot, 16_384}} = Chaos.kill_master(cluster, 16_384)
+
+    {:ok, invalid_keyslot_cluster} = FakeEndpoint.start_link(%{run: {:ok, "not-a-slot"}})
+    {:ok, failed_keyslot_cluster} = FakeEndpoint.start_link(%{run: {:error, "offline"}})
+
+    assert {:error, {:invalid_keyslot_reply, "not-a-slot"}} =
+             Chaos.kill_master(invalid_keyslot_cluster, "key")
+
+    assert {:error, {:keyslot_failed, "offline"}} =
+             Chaos.kill_master(failed_keyslot_cluster, "key")
+
+    {:ok, stopped_cluster} = FakeEndpoint.start_link(%{nodes: []})
+    GenServer.stop(stopped_cluster)
+
+    assert {:error, {:cluster_unavailable, _reason}} = Chaos.random_kill(stopped_cluster)
+  end
+
+  test "chaos cluster parser supports IPv6 and ignores transitional slot markers" do
+    cluster_nodes = """
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa [::1]:7000@17000 master - 0 0 1 connected 0-5000 [5001->-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]
+    bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 2001:db8::2:7001@17001,redis-two master - 0 0 2 connected [5001-<-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa] 5001-10000
+    cccccccccccccccccccccccccccccccccccccccc redis.example:7002@17002 master,fail - 0 0 3 connected 10001-16383
+    dddddddddddddddddddddddddddddddddddddddd 127.0.0.1:7003@17003 slave aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0 0 4 connected 12000
+    """
+
+    assert {:ok, {"::1", 7000}} = Chaos.master_addr_for_slot(cluster_nodes, 0)
+    assert {:ok, {"2001:db8::2", 7001}} = Chaos.master_addr_for_slot(cluster_nodes, 5_001)
+
+    assert {:error, {:slot_not_found, 12_000}} =
+             Chaos.master_addr_for_slot(cluster_nodes, 12_000)
+
+    malformed_slots =
+      "node redis.example:7000@17000 master - 0 0 1 connected banana 20-nope 50-10"
+
+    assert {:error, {:slot_not_found, 20}} =
+             Chaos.master_addr_for_slot(malformed_slots, 20)
+
+    malformed_address = "node no-port master - 0 0 1 connected 20"
+
+    assert {:error, {:invalid_node_address, "no-port"}} =
+             Chaos.master_addr_for_slot(malformed_address, 20)
+
+    assert {:error, {:invalid_node_address, "[::1]bad"}} =
+             Chaos.master_addr_for_slot("node [::1]bad master - 0 0 1 connected 20", 20)
+
+    assert {:error, {:invalid_node_address, ":7000"}} =
+             Chaos.master_addr_for_slot("node :7000 master - 0 0 1 connected 20", 20)
+
+    assert {:error, {:invalid_node_address, "redis.example:bad"}} =
+             Chaos.master_addr_for_slot(
+               "node redis.example:bad master - 0 0 1 connected 20",
+               20
+             )
+
+    assert {:error, {:invalid_slot, 16_384}} =
+             Chaos.master_addr_for_slot(cluster_nodes, 16_384)
   end
 
   test "private file helpers create, replace, and harden filesystem state", %{


### PR DESCRIPTION
Closes #60

## Summary
- route Redis process signals through `OSProcess` and return structured failures for missing/dead PIDs, unavailable `kill`, and failed recovery
- make memory fill, random kill, and partition operations validate empty/invalid input and roll back partial freezes
- parse IPv4, hostnames, bracketed/unbracketed IPv6, and stable slot ranges without treating migration/import markers as ownership
- add deterministic edge-case coverage and assert live chaos-operation results

## Validation
- `mix test --cover` — 108 tests, 90.49% line coverage
- `mix test test/redis_server_wrapper_unit_test.exs test/chaos_test.exs` — 34 tests
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`
- `mix hex.build --output /tmp/redis_server_wrapper-0.7.3-chaos-check.tar`