### PR TITLE
Publish complete support and usage guides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,12 @@ jobs:
       - name: Run standalone, Cluster, Sentinel, and module tests
         run: mix test
 
+      - name: Run shipped module-loading example
+        env:
+          REDIS_MODULE: ${{ env.REDIS_TEST_MODULE }}
+          REDIS_MODULE_NAME: wrapper_version_matrix
+        run: mix run examples/module_loading.exs
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ def deps do
 end
 ```
 
+## Documentation
+
+- [Support policy](guides/support.md) — Redis, Elixir/OTP, OS, distribution,
+  transport, and external-module compatibility.
+- [Configuration reference](guides/configuration.md) — complete
+  Config/Server/Cluster/Sentinel/Manager option matrices.
+- [Security and data safety](guides/security.md) — credentials, generated
+  files, network exposure, process arguments, and destructive operations.
+- [Testing and troubleshooting](guides/testing.md) — ExUnit fixtures, parallel
+  port allocation, topology port ranges, custom modules, and failure diagnosis.
+
 ## Prerequisites
 
 You need `redis-server` and `redis-cli` installed and available on your PATH.
@@ -48,6 +59,11 @@ CI runs the full standalone, Cluster, and Sentinel suite against a current patch
 release from each line, including a custom-module startup test. New patch
 releases within those lines are supported; older releases may work but are not
 part of the compatibility contract.
+
+CI verifies Linux, Elixir 1.19 / OTP 27, and Elixir 1.20 / OTP 29. macOS is
+supported for local development and maintainer-tested; native Windows is not
+supported. See the [support policy](guides/support.md) for the complete
+compatibility and platform contract.
 
 Startup uses the core `redis-server` on PATH by default:
 
@@ -149,6 +165,10 @@ BEAM instances must not write to the same Manager state file concurrently.
 Invalid state is moved aside as an `instances.json.corrupt-*` recovery copy
 instead of being overwritten.
 
+Manager state contains plaintext credentials. Review
+[security and data safety](guides/security.md) before sharing a state path or
+binding an instance beyond loopback.
+
 ### Managed Process Lifecycle
 
 `Server.start_link/1` accepts a `:managed` option controlling how the
@@ -239,6 +259,15 @@ The original raw directive form remains supported for compatibility, such as
 `loadmodule: ["/path/module.so events expired"]`, but the structured form is
 recommended when arguments are present.
 
+The repository compiles a minimal module and runs both its integration test and
+the shipped generic example on every Redis version in CI:
+
+```bash
+REDIS_MODULE=/absolute/path/to/module.so \
+REDIS_MODULE_NAME=my_module \
+  mix run examples/module_loading.exs
+```
+
 For a complete event-stream demo using
 [`redis-event-stream-module`](https://github.com/joshrotenberg/redis-event-stream-module):
 
@@ -247,12 +276,24 @@ EVENT_STREAM_MODULE=/absolute/path/to/libredis_event_stream_module.so \
   mix run examples/event_stream.exs
 ```
 
+Redis modules are native libraries and must match the target OS, architecture,
+Redis Module API, and Redis version. Loading is CI-verified with the repository's
+minimal module; the external event-stream module must be built separately. See
+[external module support](guides/support.md#external-redis-modules).
+
 ## Configuration
 
-All Redis configuration values are encoded as individual Redis tokens, including
-paths, passwords, module arguments, and `:extra` directives. Use a string for a
-single extra argument or a list for a multi-argument directive. Extras cannot
-override wrapper-owned lifecycle or transport settings such as `port`, `bind`,
+`RedisServerWrapper.Config` is a curated typed subset of Redis configuration,
+not a claim to model every Redis directive. Server, Cluster, and Sentinel add
+operational lifecycle/topology options, while `:extra` is the escape hatch for
+untyped directives. The [configuration reference](guides/configuration.md)
+lists every accepted option and calls out fields that are generated, overridden,
+or intentionally unavailable on a topology.
+
+All values are encoded as individual Redis tokens, including paths, passwords,
+module arguments, and `:extra` directives. Use a string for a single extra
+argument or a list for a multi-argument directive. Extras cannot override
+wrapper-owned lifecycle or transport settings such as `port`, `bind`,
 `daemonize`, `pidfile`, or `dir`.
 
 ```elixir
@@ -394,7 +435,8 @@ Chaos.trigger_failover(replica)        # CLUSTER FAILOVER on a replica
 
 ## Use Cases
 
-- **Testing** -- spin up real Redis instances in ExUnit setup/teardown
+- **Testing** -- spin up real Redis instances using the
+  [ExUnit fixture and port guidance](guides/testing.md)
 - **Development** -- run Redis alongside your app without system services
 - **CI** -- no Docker layer needed, just install redis-server
 - **Cluster/Sentinel testing** -- create full topologies in a single function call

--- a/examples/event_stream.exs
+++ b/examples/event_stream.exs
@@ -1,13 +1,14 @@
 alias RedisServerWrapper.Server
 
 module_path =
-  System.get_env("EVENT_STREAM_MODULE") ||
-    raise """
-    Set EVENT_STREAM_MODULE to the absolute path of redis-event-stream-module.
+  (System.get_env("EVENT_STREAM_MODULE") ||
+     raise("""
+     Set EVENT_STREAM_MODULE to the path of redis-event-stream-module.
 
-        EVENT_STREAM_MODULE=/path/to/libredis_event_stream_module.so \
-          mix run examples/event_stream.exs
-    """
+         EVENT_STREAM_MODULE=/path/to/libredis_event_stream_module.so \
+           mix run examples/event_stream.exs
+     """))
+  |> Path.expand()
 
 unless File.regular?(module_path) do
   raise "EVENT_STREAM_MODULE does not point to a file: #{module_path}"

--- a/examples/module_loading.exs
+++ b/examples/module_loading.exs
@@ -1,0 +1,49 @@
+alias RedisServerWrapper.Server
+
+module_path =
+  (System.get_env("REDIS_MODULE") ||
+     raise("""
+     Set REDIS_MODULE to the path of a Redis module.
+
+         REDIS_MODULE=/path/to/module.so \
+           mix run examples/module_loading.exs
+     """))
+  |> Path.expand()
+
+unless File.regular?(module_path) do
+  raise "REDIS_MODULE does not point to a file: #{module_path}"
+end
+
+module_args =
+  System.get_env("REDIS_MODULE_ARGS", "")
+  |> OptionParser.split()
+
+port =
+  System.get_env("REDIS_PORT", "6460")
+  |> String.to_integer()
+
+{:ok, server} =
+  Server.start(
+    port: port,
+    save: :disabled,
+    loadmodule: [{module_path, module_args}]
+  )
+
+try do
+  {:ok, modules} = Server.run(server, ["MODULE", "LIST"])
+
+  case System.get_env("REDIS_MODULE_NAME") do
+    nil ->
+      :ok
+
+    expected_name ->
+      unless String.contains?(modules, expected_name) do
+        raise "loaded module list did not contain #{inspect(expected_name)}: #{modules}"
+      end
+  end
+
+  IO.puts("Loaded Redis module from #{module_path}")
+  IO.puts(modules)
+after
+  if Process.alive?(server), do: Server.stop(server)
+end

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,0 +1,248 @@
+# Configuration and option reference
+
+RedisServerWrapper has three configuration layers:
+
+1. `RedisServerWrapper.Config` is a typed Redis configuration builder.
+2. Server, Cluster, and Sentinel accept curated operational options and own
+   lifecycle/topology directives.
+3. `:extra` is a token-safe escape hatch for Redis directives that do not have
+   typed fields.
+
+The wrapper does not claim that every Redis directive is a typed option. Use
+the tables below to determine what is emitted, what controls `redis-cli`, and
+what a topology owns.
+
+## Typed Config options
+
+`RedisServerWrapper.Config.new/1` validates these keys and
+`RedisServerWrapper.Config.to_config_string/1` renders the Redis directives.
+Unless noted, the same key can be passed to
+`RedisServerWrapper.Server.start/1` or `RedisServerWrapper.Server.start_link/1`.
+
+### Endpoint, auth, and logging
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `port` | `6379` | Plain TCP listener, `0..65_535`; `0` disables plaintext TCP. |
+| `bind` | `"127.0.0.1"` | One address, a whitespace-separated string, or a list of addresses. |
+| `control_host` | `nil` | Concrete host used by `redis-cli` and lifecycle probes. Derived from the first bind address; required when that address is a wildcard. Not emitted to Redis. |
+| `username` | `nil` | Named ACL user. Requires a string `password`; disables the default user unless the name is `"default"`. |
+| `password` | `nil` | `requirepass` when no username is set, otherwise the named ACL user's password. |
+| `loglevel` | `:notice` | One of `:debug`, `:verbose`, `:notice`, or `:warning`. |
+| `logfile` | `nil` | Redis log path. Server supplies a generated private node-directory path when omitted. |
+| `daemonize` | `false` | Direct Config value. Server overrides it from `managed`: foreground for `true`/`:forcola`, daemonized for `false`. |
+| `pidfile` | `nil` | Direct Config value. Server always supplies a generated node-directory path. |
+| `dir` | `nil` | Redis working directory. Server always supplies its generated node directory. |
+
+At least one of `port > 0`, `tls_port`, or `unixsocket` must be enabled.
+
+### Persistence, memory, and TCP
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `save` | `:default` | `:default` leaves Redis defaults untouched; `:disabled` emits an empty `save`; a list of `{positive_seconds, positive_changes}` emits explicit policies. |
+| `appendonly` | `false` | Enables AOF persistence. |
+| `appendfsync` | `:everysec` | One of `:always`, `:everysec`, or `:no`. |
+| `maxmemory` | `nil` | Redis memory limit string, for example `"256mb"`. |
+| `maxmemory_policy` | `nil` | Redis eviction policy string, for example `"allkeys-lru"`. |
+| `tcp_backlog` | `nil` | Non-negative Redis TCP listen backlog. |
+| `timeout` | `nil` | Redis idle-client timeout when using `Config` directly. On `Server`, the `timeout` keyword is instead the wrapper startup timeout; use of the Redis directive through Server is intentionally unavailable because `:extra` cannot override wrapper-owned `timeout`. |
+| `tcp_keepalive` | `nil` | Non-negative Redis TCP keepalive interval. |
+| `unixsocket` | `nil` | Standalone Unix socket path, at most 103 bytes for portable macOS/Linux support. |
+| `unixsocketperm` | `nil` | Redis socket mode string, for example `"700"`. |
+
+### TLS
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `tls_port` | `nil` | TLS listener, `1..65_535`. Enables TLS configuration and makes TLS the lifecycle connection. |
+| `tls_cert_file` | `nil` | Required TLS server certificate when `tls_port` is set. |
+| `tls_key_file` | `nil` | Required TLS server private key when `tls_port` is set. |
+| `tls_ca_cert_file` | `nil` | Trusted CA file used by Redis and `redis-cli`; mutually exclusive with `tls_ca_cert_dir`. |
+| `tls_ca_cert_dir` | `nil` | Trusted CA directory; mutually exclusive with `tls_ca_cert_file`. Exactly one CA source is required. |
+| `tls_auth_clients` | `nil` | `nil`, `"yes"`, `"no"`, or `"optional"`. Redis's default is client-certificate authentication. |
+| `tls_client_cert_file` | `nil` | `redis-cli` client certificate. Required with its key when client auth is `nil`/`"yes"`. Not emitted to Redis. |
+| `tls_client_key_file` | `nil` | `redis-cli` client private key. Not emitted to Redis. |
+| `tls_server_name` | `nil` | `redis-cli` SNI/hostname-verification name. Not emitted to Redis. |
+| `tls_insecure` | `false` | Disables `redis-cli` certificate verification. Not emitted to Redis. |
+| `tls_replication` | `false` | Emits `tls-replication yes`; Sentinel sets this for TLS data nodes. |
+| `tls_cluster` | `false` | Emits `tls-cluster yes`; Cluster sets this for TLS nodes. |
+
+To run TLS-only, set `port: 0`. To use both plaintext and TLS listeners, leave a
+positive `port`; lifecycle commands still use TLS whenever `tls_port` is set.
+
+### Replication and Cluster directives
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `replicaof` | `nil` | `{host, port}` for a standalone replica. Sentinel owns this for its replicas. |
+| `masteruser` | `nil` | ACL username used for replication; requires `replicaof` and `masterauth`. |
+| `masterauth` | `nil` | Replication password; requires `replicaof`. |
+| `cluster_enabled` | `false` | Emits `cluster-enabled yes`. Cluster owns this for its nodes. |
+| `cluster_config_file` | `nil` | Redis Cluster state filename. Cluster generates a per-node filename. |
+| `cluster_node_timeout` | `nil` | Non-negative Cluster node timeout in milliseconds. |
+| `cluster_announce_hostname` | `nil` | Explicit Cluster announcement hostname. |
+| `cluster_announce_port` | `nil` | Explicit Cluster data port, `1..65_535`. |
+| `cluster_announce_bus_port` | `nil` | Explicit Cluster bus port, `1..65_535`. |
+
+### Modules and raw directives
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `loadmodule` | `[]` | Module paths or `{path, [string_args]}` tuples. Every token is quoted/escaped when needed. |
+| `extra` | `[]` | `{directive, string_or_nonempty_string_vector}` tuples for untyped Redis directives. |
+
+Use an argument vector for multi-token directives:
+
+```elixir
+extra: [
+  {"notify-keyspace-events", "KEA"},
+  {"client-output-buffer-limit", ["pubsub", "32mb", "8mb", "60"]}
+]
+```
+
+Directive names are case-insensitive and must contain letters, numbers, and
+hyphens. `:extra` cannot replace wrapper-owned fields, including endpoint,
+auth, TLS, persistence, replication, Cluster, module, PID, directory, and
+process-lifecycle directives. Unknown Redis directives are accepted by the
+builder and may still be rejected by the selected Redis version.
+
+## Server options
+
+`Server.start/1` and `Server.start_link/1` accept the Config keys above plus:
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `name` | `nil` | GenServer registration name. Removed before Config construction. |
+| `redis_server_bin` | distribution default | Executable name or path. |
+| `redis_cli_bin` | `"redis-cli"` | Executable name or path used for readiness, commands, and shutdown. |
+| `distribution` | `:core` | `:core`, `:full`, or `:legacy_stack`; see the [support policy](support.md). |
+| `timeout` | `10_000` | Wrapper startup/readiness timeout in milliseconds. This shadows the Config field with the same name. |
+| `managed` | `true` | `true` for a foreground Port, `:forcola` for guaranteed owner-death cleanup, or `false` for a detached Redis daemon. |
+
+Server owns `daemonize`, `pidfile`, and `dir` even if values are supplied. It
+honors an explicit `logfile`, otherwise it generates one beside `redis.conf`.
+Only `managed: false` can be detached with `Server.detach/1`.
+
+## Cluster options
+
+Cluster accepts exactly this topology surface; it does not forward every Config
+field.
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `name` | `nil` | Cluster GenServer registration name. |
+| `masters` | `3` | Positive master count. |
+| `replicas_per_master` | `0` | Non-negative replica count for each master. |
+| `base_port` | `7100` | First data/TLS port. Nodes use consecutive ports. |
+| `bind` | `"127.0.0.1"` | Node listen address(es). |
+| `control_host` | first bind | Concrete host for commands and Cluster announcements. |
+| `username` / `password` | `nil` | Password-only or named ACL authentication on every node. |
+| `tls` | `false` | Creates TLS-only Cluster nodes when true. |
+| TLS certificate/client options | `nil` / `false` | `tls_cert_file`, `tls_key_file`, one CA source, `tls_auth_clients`, client certificate/key, `tls_server_name`, and `tls_insecure`. |
+| `redis_server_bin` | distribution default | Redis executable name/path. |
+| `redis_cli_bin` | `"redis-cli"` | CLI executable name/path. |
+| `distribution` | `:core` | `:core`, `:full`, or `:legacy_stack`. |
+| `timeout` | `10_000` | Per-node process-readiness timeout. |
+| `convergence_timeout` | value of `timeout` | Bounded wait for every node to report a healthy agreed topology. |
+| `cluster_node_timeout` | `5_000` | Positive Cluster node timeout in milliseconds. |
+| `loadmodule` | `[]` | Modules loaded into every node. |
+| `extra` | `[]` | Raw non-reserved Redis directives loaded into every node. |
+| `managed` | `true` | Lifecycle backend forwarded to every node. Only `false` supports `Cluster.detach/1`. |
+
+For `N = masters * (1 + replicas_per_master)`, Cluster uses data ports
+`base_port..base_port+N-1` and bus ports exactly 10,000 higher. Both ranges are
+validated for overlap and overflow. Unix sockets are rejected.
+
+## Sentinel options
+
+Sentinel accepts exactly this topology surface:
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `name` | `nil` | Sentinel topology GenServer registration name. |
+| `master_name` | `"mymaster"` | Name monitored by Sentinel. |
+| `master_port` | `6390` | Master data/TLS port. |
+| `replicas` | `2` | Non-negative replica count. |
+| `replica_base_port` | `master_port + 1` | First consecutive replica port. |
+| `sentinels` | `3` | Positive Sentinel control-process count. |
+| `sentinel_base_port` | `26_389` | First consecutive Sentinel control port. |
+| `quorum` | `2` | Positive quorum, no greater than `sentinels`. |
+| `down_after_ms` | `5_000` | Sentinel down-after-milliseconds value. |
+| `failover_timeout_ms` | `10_000` | Sentinel failover-timeout value. |
+| `bind` | `"127.0.0.1"` | Listen address(es) for data and control processes. |
+| `control_host` | first bind | Concrete host used for replication, monitoring, and commands. |
+| `username` / `password` | `nil` | Password-only or named ACL auth for data/control nodes and monitoring. |
+| `tls` | `false` | Creates TLS-only Redis and Sentinel listeners when true. |
+| TLS certificate/client options | `nil` / `false` | Same TLS fields accepted by Cluster. |
+| `redis_server_bin` | distribution default | Used to start both Redis and `--sentinel` processes. |
+| `redis_cli_bin` | `"redis-cli"` | CLI executable name/path. |
+| `distribution` | `:core` | `:core`, `:full`, or `:legacy_stack`. |
+| `timeout` | `10_000` | Per-process readiness timeout. |
+| `convergence_timeout` | value of `timeout` | Bounded replication and Sentinel-discovery wait. |
+| `loadmodule` | `[]` | Modules loaded into master and replicas, never Sentinel control processes. |
+| `managed` | `true` | Lifecycle backend used by data and control processes. Only `false` supports `Sentinel.detach/1`. |
+
+All master, replica, and Sentinel port ranges must be valid, free, and
+non-overlapping. Unix sockets and arbitrary `:extra` data-node directives are
+not part of the Sentinel surface.
+
+## Manager options
+
+Manager always launches detached (`managed: false`) processes and records their
+credentials/endpoints in its state file. It intentionally exposes a narrower
+surface than Server, Cluster, and Sentinel.
+
+### `Manager.start_basic/1`
+
+| Option | Default | Meaning |
+| --- | --- | --- |
+| `name` | generated | Persistent instance name. |
+| `port` | `6379` | Plain listener; use `0` with TLS or a Unix socket. |
+| `password` | generated | Omit to generate; pass `nil` explicitly for no auth. |
+| `username` | `nil` | Named ACL user paired with password. |
+| `bind` / `control_host` | loopback / derived | Server listen and control addresses. |
+| `persist` | `false` | Enables default RDB policy and AOF. |
+| `maxmemory` | `nil` | Redis memory limit. |
+| `loadmodule` | `[]` | Modules loaded into the server. |
+| `distribution` | `:core` | Redis distribution selection. |
+| `extra` | `[]` | Raw non-reserved Redis directives. |
+| Unix/TLS options | unset | `unixsocket`, `unixsocketperm`, `tls_port`, certificate/CA/client fields, `tls_server_name`, and `tls_insecure`. |
+
+The `tls` boolean is ignored for basic instances; setting `tls_port` selects
+TLS. Manager does not forward custom binary paths, startup timeouts, or other
+typed Config fields.
+
+### `Manager.start_cluster/1`
+
+Accepted keys are `name`, `masters`, `replicas_per_master`, `base_port`,
+`password`, `username`, `bind`, `control_host`, `loadmodule`, `distribution`,
+`tls`, and the TLS certificate/client fields. Defaults match Cluster. Manager
+does not forward Cluster `extra`, timeout, node-timeout, binary, or managed
+options.
+
+### `Manager.start_sentinel/1`
+
+Accepted keys are `name`, `master_port`, `replicas`, `sentinels`, `quorum`,
+`sentinel_base_port`, `password`, `username`, `bind`, `control_host`,
+`loadmodule`, `distribution`, `tls`, and the TLS certificate/client fields.
+Defaults match Sentinel except Manager derives quorum as `min(2, sentinels)`.
+Manager does not forward `replica_base_port`, timing, binary, raw Config, or
+managed options.
+
+### Manager state and operations
+
+The application environment key
+`:redis_server_wrapper, :manager_state_file` changes the default
+`~/.config/redis-server-wrapper/instances.json` path.
+
+The public operations are:
+
+- `list/1` (optionally `:basic`, `:cluster`, or `:sentinel`);
+- `info/1` for stored data plus live status;
+- `credentials/1` for intentionally retrieving unredacted auth/URL data;
+- `stop/1` and `stop_all/0` for ownership-checked destructive shutdown;
+- `cleanup/0` for removing stopped entries without signaling live processes.
+
+See [security and data safety](security.md) before using persistent Manager
+instances outside an isolated developer machine.

--- a/guides/security.md
+++ b/guides/security.md
@@ -1,0 +1,87 @@
+# Security and data safety
+
+RedisServerWrapper starts real operating-system processes and writes real Redis
+configuration. Treat its generated files and Manager state as credentials, and
+treat stop/cleanup/chaos operations as production-inappropriate unless that is
+explicitly your intent.
+
+## Credentials and generated files
+
+Passwords, ACL definitions, replication credentials, TLS key paths, and raw
+directives are written to generated Redis or Sentinel configuration files.
+Server and Sentinel configuration directories are created with mode `0700`;
+configuration, PID, and Manager state files use `0600`. Sentinel is launched
+under a private umask because Redis rewrites `sentinel.conf` as topology state
+changes.
+
+The Manager stores connection data and plaintext passwords in
+`~/.config/redis-server-wrapper/instances.json` by default. Its console output
+redacts credentials, but `Manager.credentials/1`, `Server.info/1`, and
+connection structs intentionally return them to the caller. Do not log or
+serialize those values without applying your own redaction.
+
+Manager writes are atomic and serialized across connected BEAM nodes.
+Independent, unconnected BEAM instances must not share one state file. A custom
+path can be configured:
+
+```elixir
+config :redis_server_wrapper,
+  manager_state_file: "/private/path/redis-server-wrapper.json"
+```
+
+The parent directory must already have an appropriate trust boundary if it is
+not the default path.
+
+## Process arguments and environment
+
+Redis is launched with the generated configuration path, rather than with
+passwords on its command line. `redis-cli` authentication uses the
+`REDISCLI_AUTH` child-process environment variable instead of `-a`, keeping the
+password out of the argument vector. Environment variables may still be
+observable to privileged users on some systems.
+
+Module paths and legacy Stack module discovery may appear in the Redis argument
+vector. Do not use module paths or load arguments as a secret-storage channel;
+load arguments are also written to `redis.conf`.
+
+## Network exposure
+
+The default bind address is loopback-only (`127.0.0.1`). If you bind to
+`0.0.0.0`, `::`, or another non-loopback address:
+
+- configure a password or named ACL user;
+- apply host/network firewall rules;
+- use TLS for untrusted networks;
+- set `control_host` to one concrete reachable address;
+- review Redis protected-mode and module exposure for your environment.
+
+`tls_insecure: true` disables server-certificate verification for lifecycle
+commands. It is intended only for controlled tests. For mutual TLS, keep client
+private keys readable only by the test account.
+
+## Stop, cleanup, and chaos semantics
+
+`Server.stop/1`, `Cluster.stop/1`, and `Sentinel.stop/1` send `SHUTDOWN NOSAVE`.
+Unsaved data is deliberately discarded. The Manager's `stop/1` and
+`stop_all/0` do the same for detached instances.
+
+Before signaling a Manager-owned process, the Manager uses listener ownership
+to match the currently bound process against its recorded PID. If ownership
+cannot be verified, it refuses destructive cleanup rather than signaling an
+unknown process. `Manager.cleanup/0` only removes state entries that appear
+stopped; it does not stop live instances.
+
+The `RedisServerWrapper.Chaos` API is intentionally destructive:
+
+- `kill_node/1` and `kill_master/2` use SIGKILL;
+- `flushall/1` deletes every key;
+- `fill_memory/2` writes data and can trigger eviction or OOM behavior;
+- partition/freeze operations can make a topology unavailable.
+
+Use isolated ports and disposable data directories. Always recover frozen PIDs
+in `on_exit`/`after` cleanup, and propagate the structured errors returned by
+Chaos rather than assuming a signal was delivered.
+
+The default managed Port backend can strand a child after a hard BEAM death or
+`:brutal_kill`, because OTP does not run `terminate/2` on those paths. Use
+`managed: :forcola` when child cleanup must survive those termination modes.

--- a/guides/support.md
+++ b/guides/support.md
@@ -1,0 +1,88 @@
+# Support policy
+
+This document defines the compatibility contract for RedisServerWrapper. A
+version may work outside these ranges, but it is not considered supported until
+it is represented in CI or explicitly listed here.
+
+## Runtime matrix
+
+| Component | Supported | Verification |
+| --- | --- | --- |
+| Redis | 7.2, 7.4, 8.2, and the latest Redis 8.x line | The full standalone, Cluster, Sentinel, TLS, and custom-module suite runs on Redis 7.2.14, 7.4.9, 8.2.6, and 8.8.0. Patch releases within a listed line are supported. |
+| Elixir / OTP | Elixir 1.19+ | CI verifies Elixir 1.19 / OTP 27 and Elixir 1.20 / OTP 29. |
+| Linux | Supported | Every CI job runs on GitHub-hosted Ubuntu. |
+| macOS | Supported for local development and testing | The suite is maintainer-tested on macOS. Port 7000 is avoided because AirPlay Receiver commonly owns it. |
+| Windows | Not supported natively | Process lifecycle and Sentinel use POSIX process behavior and `/bin/sh`. WSL may work as Linux, but is not in CI. |
+
+`redis-server` and `redis-cli` must be mutually compatible and available on
+`PATH`, unless explicit binary paths are provided. `kill` is required by
+`RedisServerWrapper.Chaos`. `lsof` and `kill` improve ownership checks and
+forced teardown; ordinary managed lifecycle paths degrade safely if they are
+missing.
+
+The optional `managed: :forcola` backend is POSIX-only. It provides stronger
+child-process cleanup than the default Port backend.
+
+## Redis distributions
+
+Redis 8's Full distribution uses the same `redis-server` executable as Redis
+Open Source. RedisServerWrapper therefore treats `:core` and `:full` the same
+at process launch: both resolve `redis-server` from `PATH`. Modules bundled
+with a Full installation remain Redis's responsibility.
+
+Legacy Redis Stack is different. Select it explicitly:
+
+```elixir
+RedisServerWrapper.start_server(
+  distribution: :legacy_stack,
+  redis_server_bin: "/opt/redis-stack/bin/redis-server"
+)
+```
+
+When `distribution: :legacy_stack` is selected, the wrapper may discover
+legacy sibling modules next to the Stack server binary. It never performs that
+discovery for `:core` or `:full`. If `:redis_server_bin` is omitted, legacy
+selection uses `REDIS_LEGACY_STACK_SERVER_BIN` and then falls back to
+`redis-stack-server`.
+
+An explicit `:redis_server_bin` always wins. Explicit `:loadmodule` entries are
+honored for every distribution.
+
+## Topology and transport support
+
+| Surface | TCP | TLS | Unix socket | ACL username + password |
+| --- | --- | --- | --- | --- |
+| Server | Yes | Yes, including TLS-only and mTLS | Yes, including Unix-only | Yes |
+| Cluster | Yes | Yes, TLS-only nodes | No | Yes |
+| Sentinel | Yes | Yes, TLS-only data and control nodes | No | Yes |
+| Manager basic | Yes | Yes | Yes | Yes |
+| Manager Cluster / Sentinel | Yes | Yes | No | Yes |
+
+Cluster and Sentinel reject Unix sockets because their members must advertise
+and reach network endpoints. `:control_host` is used for readiness checks,
+replication, Cluster announcements, and Sentinel monitoring; set it explicitly
+when the first bind address is a wildcard.
+
+See the [configuration reference](configuration.md) for option-level details
+and the [testing guide](testing.md) for required data, Cluster bus, replica, and
+Sentinel ports.
+
+## External Redis modules
+
+Redis modules are native shared libraries. Compatibility depends on all of:
+
+- the operating system and CPU architecture;
+- the Redis Module API used to build the module;
+- the Redis major/minor line;
+- the module's own load arguments and dependencies.
+
+RedisServerWrapper safely writes module paths and arguments, but cannot make an
+incompatible binary loadable. Build or obtain a module for the same platform
+and a Redis version supported by that module, then test `MODULE LIST` and the
+module's commands on every Redis line you plan to deploy.
+
+The repository compiles and runs the shipped
+`test/support/version_matrix_module.c` example across every Redis version in
+the CI matrix. The `examples/event_stream.exs` demo uses the external
+`redis-event-stream-module`; that module must be built separately for the
+target Redis and platform.

--- a/guides/testing.md
+++ b/guides/testing.md
@@ -1,0 +1,198 @@
+# Testing and troubleshooting
+
+RedisServerWrapper is designed for integration tests that need a real Redis
+process without adding a Docker dependency. The examples below keep process
+ownership and port allocation explicit.
+
+## ExUnit fixture
+
+For the simplest and most predictable suite, keep Redis-owning test modules
+synchronous and use an unlinked Server with `on_exit` cleanup:
+
+```elixir
+defmodule MyRedisIntegrationTest do
+  use ExUnit.Case, async: false
+
+  alias RedisServerWrapper.Server
+
+  setup do
+    port = 16_380
+    {:ok, server} = Server.start(port: port, save: :disabled)
+
+    on_exit(fn ->
+      if Process.alive?(server), do: Server.stop(server)
+    end)
+
+    %{server: server, port: port}
+  end
+
+  test "round trips through Redis", %{server: server} do
+    assert {:ok, "OK"} = Server.run(server, ["SET", "answer", "42"])
+    assert {:ok, "42"} = Server.run(server, ["GET", "answer"])
+  end
+end
+```
+
+`Server.start/1` avoids linking the Redis owner to the individual test process.
+An OTP-supervised fixture is also valid:
+
+```elixir
+child =
+  Supervisor.child_spec(
+    {RedisServerWrapper.Server, [port: 16_381, save: :disabled]},
+    id: {:redis, 16_381}
+  )
+
+server = start_supervised!(child)
+```
+
+Use `Cluster.start/1` or `Sentinel.start/1` with the same `on_exit` pattern.
+Give topology tests a larger ExUnit timeout because startup waits for actual
+convergence:
+
+```elixir
+@tag timeout: 60_000
+test "cluster behavior" do
+  {:ok, cluster} =
+    RedisServerWrapper.Cluster.start(
+      masters: 3,
+      replicas_per_master: 1,
+      base_port: 17_000
+    )
+
+  on_exit(fn ->
+    if Process.alive?(cluster), do: RedisServerWrapper.Cluster.stop(cluster)
+  end)
+
+  assert RedisServerWrapper.Cluster.healthy?(cluster)
+end
+```
+
+## Parallel tests and ports
+
+A Redis listener must own its port exclusively. The wrapper will not terminate
+an existing listener to claim a port.
+
+Prefer one of these strategies:
+
+1. Run Redis-owning modules with `async: false` and assign fixed,
+   non-overlapping port blocks.
+2. Allocate blocks centrally with an Agent/ETS counter before tests start.
+3. Ask the OS for an ephemeral port, close the reservation, and start Redis
+   immediately. This has a small close/rebind race and is best for developer
+   tests rather than hostile multi-tenant hosts.
+
+```elixir
+def free_tcp_port do
+  {:ok, socket} =
+    :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+
+  {:ok, {_address, port}} = :inet.sockname(socket)
+  :ok = :gen_tcp.close(socket)
+  port
+end
+```
+
+Port blocks must account for the whole topology:
+
+- Server: every enabled plaintext or TLS listener.
+- Cluster: `total_nodes = masters * (1 + replicas_per_master)` consecutive data
+  ports beginning at `base_port`, plus one Cluster bus port at
+  `data_port + 10_000` for every node. Both ranges must be free and at most
+  65,535. The wrapper validates range overlap and overflow.
+- Sentinel: `master_port`, `replicas` consecutive ports beginning at
+  `replica_base_port`, and `sentinels` consecutive ports beginning at
+  `sentinel_base_port`. These ranges may not overlap.
+
+Cluster bus ports must also be reachable between nodes in a networked test
+environment. Sentinel processes must reach `control_host:master_port`, and
+replicas must reach the same concrete control host.
+
+## Modules in CI
+
+The repository's compatibility job builds
+`test/support/version_matrix_module.c`, loads it through `:loadmodule`, and runs
+the shipped `examples/module_loading.exs` on every supported Redis line.
+
+To check your own module:
+
+```bash
+REDIS_MODULE=/absolute/path/to/module.so \
+REDIS_MODULE_NAME=my_module \
+  mix run examples/module_loading.exs
+```
+
+Optional load arguments can be supplied in shell syntax:
+
+```bash
+REDIS_MODULE=/absolute/path/to/module.so \
+REDIS_MODULE_ARGS='stream-name "argument with spaces"' \
+  mix run examples/module_loading.exs
+```
+
+For the event-stream demo, build `redis-event-stream-module` for the local
+platform and Redis line, then run:
+
+```bash
+EVENT_STREAM_MODULE=/absolute/path/to/libredis_event_stream_module.so \
+  mix run examples/event_stream.exs
+```
+
+## Troubleshooting
+
+### Binary not found
+
+Verify both tools resolve in the same environment as the BEAM:
+
+```bash
+redis-server --version
+redis-cli --version
+```
+
+Otherwise pass `redis_server_bin:` and `redis_cli_bin:`. See the
+[support policy](support.md) for Redis 8 Full and legacy Stack selection.
+
+### Port or socket already in use
+
+Choose another port/block and check system services. On macOS, AirPlay Receiver
+commonly owns port 7000; Cluster defaults to 7100 for that reason. A Unix socket
+path must not already exist.
+
+### Startup or convergence timeout
+
+Increase `timeout:` for process readiness and `convergence_timeout:` for
+Cluster/Sentinel agreement. Errors retain the last observed health state.
+Generated logs and configs live below the system temporary directory in
+`redis-server-wrapper/node-*` while the instance exists.
+
+For Cluster, verify both data and `+10_000` bus ports are available. For
+Sentinel, verify every master, replica, and Sentinel range is non-overlapping.
+
+### TLS failure
+
+TLS requires a server certificate, key, and exactly one CA file or CA
+directory. Redis requires client certificates by default; either supply
+`tls_client_cert_file` and `tls_client_key_file`, or explicitly set
+`tls_auth_clients: "no"`/`"optional"`.
+
+### Module fails to load
+
+Run the selected `redis-server` directly with the module to see its loader
+error. Confirm the shared-library platform, architecture, Redis Module API, and
+dependent libraries. A path that loads on Redis 7 or legacy Stack is not
+automatically compatible with Redis 8.
+
+### Leftover process after a hard test failure
+
+Normal `Server.stop/1` cleanup sends `SHUTDOWN NOSAVE`, closes managed ports,
+and verifies owned PIDs before a forced signal. A `:brutal_kill`, SIGKILL, OOM,
+or VM crash can skip OTP termination callbacks. Use `managed: :forcola` for the
+strongest owner-death cleanup, or stop an intentionally detached Manager
+instance with `Manager.stop/1`.
+
+### Missing `kill` or `lsof`
+
+Managed startup and normal graceful shutdown still work without these tools.
+Chaos signaling requires `kill`. Manager destructive cleanup may refuse to
+proceed when `lsof` is unavailable because listener ownership cannot be
+verified.

--- a/lib/redis_server_wrapper.ex
+++ b/lib/redis_server_wrapper.ex
@@ -30,7 +30,8 @@ defmodule RedisServerWrapper do
     * **Custom binaries** - point to any `redis-server`/`redis-cli` path
     * **Custom modules** - load modules with argument-safe configuration on
       standalone servers, cluster nodes, and sentinel data nodes
-    * **Arbitrary config** - pass any Redis directive via `:extra` option
+    * **Untyped config escape hatch** - pass additional non-reserved Redis
+      directives via the token-safe `:extra` option
   """
 
   alias RedisServerWrapper.{Cluster, Sentinel, Server}

--- a/lib/redis_server_wrapper/manager.ex
+++ b/lib/redis_server_wrapper/manager.ex
@@ -79,7 +79,7 @@ defmodule RedisServerWrapper.Manager do
     * `:loadmodule` - modules to load; accepts paths or `{path, [args]}` tuples
     * `:distribution` - `:core` (default), `:full`, or `:legacy_stack`
     * TCP, Unix-socket, and TLS options accepted by `RedisServerWrapper.Server`
-    * Plus any `RedisServerWrapper.Config` options via `:extra`
+    * Additional non-reserved Redis directives via `:extra`
   """
   @spec start_basic(keyword()) :: {:ok, instance()} | {:error, term()}
   def start_basic(opts \\ []) do

--- a/lib/redis_server_wrapper/server.ex
+++ b/lib/redis_server_wrapper/server.ex
@@ -14,7 +14,11 @@ defmodule RedisServerWrapper.Server do
 
   ## Options
 
-  All options from `RedisServerWrapper.Config` are supported, plus:
+  Typed options from `RedisServerWrapper.Config` are supported, subject to
+  Server-owned lifecycle fields. In particular, Server owns `:daemonize`,
+  `:pidfile`, and `:dir`, and interprets `:timeout` as its startup timeout
+  rather than Redis's idle-client directive. The shipped configuration guide
+  is the authoritative option matrix.
 
     * `:redis_server_bin` - path to redis-server binary (default: "redis-server")
     * `:redis_cli_bin` - path to redis-cli binary (default: "redis-cli")

--- a/mix.exs
+++ b/mix.exs
@@ -42,14 +42,25 @@ defmodule RedisServerWrapper.MixProject do
     [
       licenses: ["MIT", "Apache-2.0"],
       links: %{"GitHub" => @source_url},
-      files: ~w(lib examples .formatter.exs mix.exs README.md CHANGELOG.md LICENSE)
+      files: ~w(lib examples guides .formatter.exs mix.exs README.md CHANGELOG.md LICENSE)
     ]
   end
 
   defp docs do
     [
       main: "readme",
-      extras: ["README.md", "CHANGELOG.md", "LICENSE"],
+      extras: [
+        "README.md",
+        "guides/support.md",
+        "guides/configuration.md",
+        "guides/security.md",
+        "guides/testing.md",
+        "CHANGELOG.md",
+        "LICENSE"
+      ],
+      groups_for_extras: [
+        Guides: ~r/guides\//
+      ],
       source_ref: "v#{@version}",
       source_url: @source_url
     ]


### PR DESCRIPTION
Closes #61

## Summary
- publish the Redis, Elixir/OTP, OS, distribution, transport, and module compatibility contract
- add complete configuration, security/data-safety, and ExUnit/testing guides to ExDoc and the Hex package
- ship a generic module-loading example and run it across the Redis 7.2, 7.4, 8.2, and latest 8.x CI matrix
- clarify typed configuration versus raw Redis directives and wrapper-owned operational settings

## Validation
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix dialyzer`
- `mix docs`
- `mix hex.build --output /tmp/redis_server_wrapper-0.7.3-docs-check.tar`
- `mix test test/redis_server_wrapper_unit_test.exs` (20 tests)
- generic and redis-event-stream-module examples against Redis 8.8
- full local suite reached 107/108 tests and 90.10% coverage; the sole miss was a pre-existing user-owned Redis Stack cluster bound to the default cluster port 7100, which was deliberately left untouched. The clean CI runners provide the final full-suite result.